### PR TITLE
Remove redundant field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ description = "A tool to test markdown files and drive development from document
 repository = "https://github.com/specdown/specdown"
 readme = "README.md"
 license = "Apache-2.0"
-license-file = "LICENSE"
 authors = [ "Tom Oram <me@tomoram.io>" ]
 edition = "2018"
 categories = [


### PR DESCRIPTION
This removes the redundant license field. You only need license or file, and generally, file is for non-standard licenses.