### PR TITLE
fix: Easy dependency upgrading

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: ci
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: build


### PR DESCRIPTION
Add dependabot to make it simple to keep dependencies up to date.

In the future merge those in automatically with @mergifyio to minimise development overhead.