### PR TITLE
ci: Automatically merge passing dependency bumps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,28 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=lints
+      - status-success=version
+      - status-success=test (ubuntu-latest)
+      - status-success=test (macos-latest)
+      - status-success=test (windows-latest)
+      - status-success=security-audit
+      - status-success=check
+
+pull_request_rules:
+  - name: automatic rebase for dependencies
+    conditions:
+      - status-success=lints
+      - status-success=version
+      - status-success=test (ubuntu-latest)
+      - status-success=test (macos-latest)
+      - status-success=test (windows-latest)
+      - status-success=security-audit
+      - status-success=check
+      - base=master
+      - author~=^dependabot(|-preview)\[bot\]$
+    actions:
+      queue:
+        method: rebase
+        rebase_fallback: merge
+        name: default


### PR DESCRIPTION
You'll need to sign up for @mergifyio for this to work, but they have an open source tier. Merges PRs that pass into master

Won't touch things that change the git-hub actions folder though, as that'd be a security risk.