### PR TITLE
fix: Correct versio release config

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,9 +36,6 @@ jobs:
         name: Install versio
       - name: Check projects
         run: versio check
-        env:
-          RUST_LOG: versio=trace
-          RUST_BACKTRACE: 1
       - name: Print changes
         run: versio plan
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -44,8 +44,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_USER: ${{ github.actor }}
-          RUST_LOG: versio=trace
-          RUST_BACKTRACE: 1
+      - name: version bump details
+        run: versio release --dry-run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
 
   cargo-check:
     runs-on: ubuntu-latest

--- a/.versio.yaml
+++ b/.versio.yaml
@@ -10,12 +10,10 @@ projects:
           file: Cargo.toml
           toml: package.version
       also:
-          - file: README.md
-            pattern: specdown (\d+\.\d+\.\d+)
           - file: docs/cli/display_help.md
             pattern: specdown (\d+\.\d+\.\d+)
           - file: docs/cli/display_help_windows.md
-            pattern: specdown.exe (\d+\.\d+\.\d+)
+            pattern: specdown (\d+\.\d+\.\d+)
       hooks:
           post_write: cargo fetch
 


### PR DESCRIPTION
Currently it's incorrect

I got releases working locally by running after the above was merged in

```shell
git tag | xargs git tag -d
git reset --hard origin/master
git pull --tags
versio -l local set --value 0.43.1
touch file
git add file
git commit -m "fix: Version Bump"
git rm file
git commit -m "fix: Version Bump"
versio -l local release
git push -f --tags
```

Once that's working it should work remotely too