### PR TITLE
feat: Add functionality to run multiple spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Running tests for example.md:
   - verify stdout from 'hello-specdown' succeeded
 
   2 functions run (2 succeeded / 0 failed)
+
 ```
 
 ## Full Documentation

--- a/docs/cli/display_help.md
+++ b/docs/cli/display_help.md
@@ -41,7 +41,7 @@ specdown-run
 Runs a given Markdown Specification
 
 USAGE:
-    specdown run [OPTIONS] <spec-file>
+    specdown run [OPTIONS] <spec-files>...
 
 FLAGS:
     -h, --help       Prints help information
@@ -52,5 +52,5 @@ OPTIONS:
         --shell-command <shell-command>    The shell command used to execute script blocks [default: bash -c]
 
 ARGS:
-    <spec-file>    The spec file to run
+    <spec-files>...    The spec files to run
 ```

--- a/docs/cli/display_help_windows.md
+++ b/docs/cli/display_help_windows.md
@@ -41,7 +41,7 @@ specdown.exe-run
 Runs a given Markdown Specification
 
 USAGE:
-    specdown.exe run [OPTIONS] <spec-file>
+    specdown.exe run [OPTIONS] <spec-files>...
 
 FLAGS:
     -h, --help       Prints help information
@@ -52,5 +52,5 @@ OPTIONS:
         --shell-command <shell-command>    The shell command used to execute script blocks [default: bash -c]
 
 ARGS:
-    <spec-file>    The spec file to run
+    <spec-files>...    The spec files to run
 ```

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -1,6 +1,6 @@
 # Running Specs
 
-Markdown specs are run by executing the `specdown run <spec-file>`.
+Markdown specs are run by executing the `specdown run <spec-files>`.
 
 ## Example
 
@@ -35,6 +35,52 @@ Running tests for example-spec.md:
   - verify stdout from 'command_1' succeeded
 
   2 functions run (2 succeeded / 0 failed)
+
+```
+
+## Multiple Files
+
+Given a file `example-file1.md`
+
+~~~markdown,file(path="example-file1.md")
+# This is a spec
+
+```shell,script(name="command_1")
+echo "Spec 1"
+```
+~~~
+
+Given a file `example-file2.md`
+
+~~~markdown,file(path="example-file2.md")
+# This is another spec
+
+```shell,script(name="command_2")
+echo "Spec 2"
+```
+~~~
+
+You can run:
+
+```shell,script(name="run_example")
+specdown run example-file1.md example-file2.md
+```
+
+And you will get the following output:
+
+```text,verify(script_name="run_example")
+Running tests for example-file1.md:
+
+  - script 'command_1' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
+Running tests for example-file2.md:
+
+  - script 'command_2' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
 ```
 
 ## Setting the Running Directory
@@ -89,6 +135,7 @@ Running tests for running_dir_example.md:
   - verify stdout from 'cat' succeeded
 
   4 functions run (4 succeeded / 0 failed)
+
 ```
 
 ## Setting the Shell
@@ -138,6 +185,7 @@ Running tests for setting_the_shell_example.md:
 ===
 
   2 functions run (1 succeeded / 1 failed)
+
 ```
 
 
@@ -154,7 +202,7 @@ specdown-run
 Runs a given Markdown Specification
 
 USAGE:
-    specdown run [OPTIONS] <spec-file>
+    specdown run [OPTIONS] <spec-files>...
 
 FLAGS:
     -h, --help       Prints help information
@@ -165,6 +213,6 @@ OPTIONS:
         --shell-command <shell-command>    The shell command used to execute script blocks [default: bash -c]
 
 ARGS:
-    <spec-file>    The spec file to run
+    <spec-files>...    The spec files to run
 ```
 

--- a/docs/cli/running_specs_windows.md
+++ b/docs/cli/running_specs_windows.md
@@ -1,6 +1,6 @@
 # Running Specs
 
-Markdown specs are run by executing the `specdown run <spec-file>`.
+Markdown specs are run by executing the `specdown run <spec-files>`.
 
 ## Example
 
@@ -35,6 +35,52 @@ Running tests for example-spec.md:
   - verify stdout from 'command_1' succeeded
 
   2 functions run (2 succeeded / 0 failed)
+
+```
+
+## Multiple Files
+
+Given a file `example-file1.md`
+
+~~~markdown,file(path="example-file1.md")
+# This is a spec
+
+```shell,script(name="command_1")
+echo "Spec 1"
+```
+~~~
+
+Given a file `example-file2.md`
+
+~~~markdown,file(path="example-file2.md")
+# This is another spec
+
+```shell,script(name="command_2")
+echo "Spec 2"
+```
+~~~
+
+You can run:
+
+```shell,script(name="run_example")
+specdown run example-file1.md example-file2.md
+```
+
+And you will get the following output:
+
+```text,verify(script_name="run_example")
+Running tests for example-file1.md:
+
+  - script 'command_1' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
+Running tests for example-file2.md:
+
+  - script 'command_2' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
 ```
 
 ## Setting the Running Directory
@@ -89,6 +135,7 @@ Running tests for running_dir_example.md:
   - verify stdout from 'cat' succeeded
 
   4 functions run (4 succeeded / 0 failed)
+
 ```
 
 ## Setting the Shell
@@ -138,8 +185,8 @@ Running tests for setting_the_shell_example.md:
 ===
 
   2 functions run (1 succeeded / 1 failed)
-```
 
+```
 
 ## Command Help
 
@@ -154,7 +201,7 @@ specdown.exe-run
 Runs a given Markdown Specification
 
 USAGE:
-    specdown.exe run [OPTIONS] <spec-file>
+    specdown.exe run [OPTIONS] <spec-files>...
 
 FLAGS:
     -h, --help       Prints help information
@@ -165,6 +212,6 @@ OPTIONS:
         --shell-command <shell-command>    The shell command used to execute script blocks [default: bash -c]
 
 ARGS:
-    <spec-file>    The spec file to run
+    <spec-files>...    The spec files to run
 ```
 

--- a/docs/specs/creating_test_files.md
+++ b/docs/specs/creating_test_files.md
@@ -40,4 +40,5 @@ Running tests for writing_file_example.md:
   - verify stdout from 'cat-file' succeeded
 
   3 functions run (3 succeeded / 0 failed)
+
 ```

--- a/docs/specs/skipping_code_blocks.md
+++ b/docs/specs/skipping_code_blocks.md
@@ -26,4 +26,5 @@ Running tests for skip_example.md:
 
 
   0 functions run (0 succeeded / 0 failed)
+
 ```

--- a/docs/specs/verifying_exit_codes.md
+++ b/docs/specs/verifying_exit_codes.md
@@ -42,4 +42,5 @@ Running tests for exit_example.md:
 
 
   2 functions run (1 succeeded / 1 failed)
+
 ```

--- a/docs/specs/verifying_script_output.md
+++ b/docs/specs/verifying_script_output.md
@@ -55,4 +55,5 @@ Running tests for verify_example.md:
 ===
 
   3 functions run (2 succeeded / 1 failed)
+
 ```

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -129,7 +129,7 @@ impl Printer for BasicPrinter {
 
     fn print_summary(&self, summary: &Summary) {
         self.display(&format!(
-            "\n  {} functions run ({} succeeded / {} failed)",
+            "\n  {} functions run ({} succeeded / {} failed)\n",
             summary.number_failed + summary.number_succeeded,
             summary.number_succeeded,
             summary.number_failed


### PR DESCRIPTION
Enables you to list multiple files when calling `specdown run`

closes: #10