### PR TITLE
ci: Update automerge rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,24 +1,24 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=lints
-      - status-success=version
-      - status-success=test (ubuntu-latest)
-      - status-success=test (macos-latest)
-      - status-success=test (windows-latest)
-      - status-success=security-audit
-      - status-success=check
+      - status-success=lint
+      - status-success=versio-plan
+      - status-success=cargo-test (ubuntu-latest)
+      - status-success=cargo-test (macos-latest)
+      - status-success=cargo-test (windows-latest)
+      - status-success=cargo-audit
+      - status-success=cargo-check
 
 pull_request_rules:
   - name: automatic rebase for dependencies
     conditions:
-      - status-success=lints
-      - status-success=version
-      - status-success=test (ubuntu-latest)
-      - status-success=test (macos-latest)
-      - status-success=test (windows-latest)
-      - status-success=security-audit
-      - status-success=check
+      - status-success=lint
+      - status-success=versio-plan
+      - status-success=cargo-test (ubuntu-latest)
+      - status-success=cargo-test (macos-latest)
+      - status-success=cargo-test (windows-latest)
+      - status-success=cargo-audit
+      - status-success=cargo-check
       - base=master
       - author~=^dependabot(|-preview)\[bot\]$
     actions:


### PR DESCRIPTION
These are currently wrong, meaning the pipeline won't merge dependabot bumps.