### PR TITLE
BasicPrinter refactorings

### DIFF
--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -1,4 +1,6 @@
-use crate::types::{CreateFileAction, OutputExpectation, ScriptAction, VerifyAction, VerifyValue};
+use crate::types::{
+    CreateFileAction, ExitCode, OutputExpectation, ScriptAction, VerifyAction, VerifyValue,
+};
 
 #[derive(Debug, PartialEq)]
 pub enum ActionError {
@@ -14,15 +16,16 @@ trait ActionErrorProvider {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScriptResult {
     pub action: ScriptAction,
-    pub exit_code: Option<i32>,
+    pub exit_code: Option<ExitCode>,
     pub stdout: String,
     pub stderr: String,
 }
 
 impl ActionErrorProvider for ScriptResult {
     fn error(&self) -> Option<ActionError> {
-        let i32_exit_code = self.action.expected_exit_code.map(i32::from);
-        if i32_exit_code != None && i32_exit_code != self.exit_code {
+        if self.action.expected_exit_code != None
+            && self.action.expected_exit_code != self.exit_code
+        {
             return Some(ActionError::ExitCodeIsIncorrect(self.clone()));
         }
 
@@ -135,7 +138,7 @@ mod tests {
                         expected_exit_code: Some(ExitCode(1)),
                         expected_output: OutputExpectation::Any,
                     },
-                    exit_code: Some(1),
+                    exit_code: Some(ExitCode(1)),
                     stdout: "".to_string(),
                     stderr: "".to_string(),
                 });
@@ -152,7 +155,7 @@ mod tests {
                         expected_exit_code: Some(ExitCode(1)),
                         expected_output: OutputExpectation::Any,
                     },
-                    exit_code: Some(2),
+                    exit_code: Some(ExitCode(2)),
                     stdout: "".to_string(),
                     stderr: "".to_string(),
                 };

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -134,30 +134,27 @@ impl BasicPrinter {
     }
 
     fn action_result_message(result: &ActionResult) -> String {
-        if let Some(error) = result.error() {
-            match error {
-                ActionError::ExitCodeIsIncorrect(result) => {
-                    format!(
-                        "failed (expected exitcode {}, got {})",
-                        BasicPrinter::exit_code_to_string(result.action.expected_exit_code),
-                        BasicPrinter::exit_code_to_string(result.exit_code),
-                    )
-                }
-                ActionError::UnexpectedOutputIsPresent(result) => {
-                    format!(
-                        "failed (unexpected {})",
-                        match result.action.expected_output {
-                            OutputExpectation::Any => panic!("Should not be possible"),
-                            OutputExpectation::StdOut => "stderr",
-                            OutputExpectation::StdErr => "stdout",
-                            OutputExpectation::None => "output",
-                        }
-                    )
-                }
-                ActionError::OutputDoesNotMatch(_) => "failed".to_string(),
+        match result.error() {
+            Some(ActionError::ExitCodeIsIncorrect(result)) => {
+                format!(
+                    "failed (expected exitcode {}, got {})",
+                    BasicPrinter::exit_code_to_string(result.action.expected_exit_code),
+                    BasicPrinter::exit_code_to_string(result.exit_code),
+                )
             }
-        } else {
-            "succeeded".to_string()
+            Some(ActionError::UnexpectedOutputIsPresent(result)) => {
+                format!(
+                    "failed (unexpected {})",
+                    match result.action.expected_output {
+                        OutputExpectation::Any => panic!("Should not be possible"),
+                        OutputExpectation::StdOut => "stderr",
+                        OutputExpectation::StdErr => "stdout",
+                        OutputExpectation::None => "output",
+                    }
+                )
+            }
+            Some(ActionError::OutputDoesNotMatch(_)) => "failed".to_string(),
+            None => "succeeded".to_string(),
         }
     }
 

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -7,7 +7,7 @@ use super::printer::Printer;
 use crate::results::action_result::{ActionError, CreateFileResult, ScriptResult, VerifyResult};
 use crate::runner::error::Error;
 use crate::runner::RunEvent;
-use crate::types::{OutputExpectation, Stream, VerifyAction};
+use crate::types::{ExitCode, OutputExpectation, Stream, VerifyAction};
 
 struct Summary {
     pub number_succeeded: u32,
@@ -60,7 +60,7 @@ impl BasicPrinter {
         self.count_action(result);
         self.display_action(result);
         if let Some(error) = result.error() {
-            self.dsiplay_action_error(&error);
+            self.display_action_error(&error);
         }
     }
 
@@ -139,17 +139,8 @@ impl BasicPrinter {
                 ActionError::ExitCodeIsIncorrect(result) => {
                     format!(
                         "failed (expected exitcode {}, got {})",
-                        result
-                            .action
-                            .expected_exit_code
-                            .map(String::from)
-                            .or_else(|| Some("None".to_string()))
-                            .unwrap(),
-                        result
-                            .exit_code
-                            .map(|code| code.to_string())
-                            .or_else(|| Some("None".to_string()))
-                            .unwrap()
+                        BasicPrinter::exit_code_to_string(result.action.expected_exit_code),
+                        BasicPrinter::exit_code_to_string(result.exit_code),
                     )
                 }
                 ActionError::UnexpectedOutputIsPresent(result) => {
@@ -170,7 +161,14 @@ impl BasicPrinter {
         }
     }
 
-    fn dsiplay_action_error(&mut self, error: &ActionError) {
+    fn exit_code_to_string(exit_code: Option<ExitCode>) -> String {
+        exit_code
+            .map(String::from)
+            .or_else(|| Some("None".to_string()))
+            .unwrap()
+    }
+
+    fn display_action_error(&mut self, error: &ActionError) {
         match error {
             ActionError::ExitCodeIsIncorrect(ScriptResult { stdout, stderr, .. })
             | ActionError::UnexpectedOutputIsPresent(ScriptResult { stdout, stderr, .. }) => {

--- a/src/runner/script.rs
+++ b/src/runner/script.rs
@@ -1,5 +1,5 @@
 use crate::results::action_result::{ActionResult, ScriptResult};
-use crate::types::ScriptAction;
+use crate::types::{ExitCode, ScriptAction};
 
 use super::error::Error;
 use super::executor::{Executor, Output};
@@ -15,7 +15,7 @@ pub fn run(action: &ScriptAction, executor: &dyn Executor) -> Result<ActionResul
          }| {
             ActionResult::Script(ScriptResult {
                 action: action.clone(),
-                exit_code,
+                exit_code: exit_code.map(ExitCode),
                 stdout,
                 stderr,
             })

--- a/src/runner/state.rs
+++ b/src/runner/state.rs
@@ -90,7 +90,7 @@ mod tests {
         };
         let script_result1 = ActionResult::Script(ScriptResult {
             action,
-            exit_code: Some(0),
+            exit_code: Some(ExitCode(0)),
             stdout: "stderr1".to_string(),
             stderr: "stderr1".to_string(),
         });
@@ -109,7 +109,7 @@ mod tests {
         };
         let script_result1 = ActionResult::Script(ScriptResult {
             action,
-            exit_code: Some(2),
+            exit_code: Some(ExitCode(2)),
             stdout: "stderr1".to_string(),
             stderr: "stderr1".to_string(),
         });
@@ -139,7 +139,7 @@ mod tests {
                 expected_exit_code: None,
                 expected_output: OutputExpectation::Any,
             },
-            exit_code: Some(0),
+            exit_code: Some(ExitCode(0)),
             stdout: "stdout1".to_string(),
             stderr: "stderr1".to_string(),
         });
@@ -150,7 +150,7 @@ mod tests {
                 expected_exit_code: None,
                 expected_output: OutputExpectation::Any,
             },
-            exit_code: Some(0),
+            exit_code: Some(ExitCode(0)),
             stdout: "stdout2".to_string(),
             stderr: "stderr2".to_string(),
         });
@@ -176,7 +176,7 @@ mod tests {
                 expected_exit_code: None,
                 expected_output: OutputExpectation::Any,
             },
-            exit_code: Some(0),
+            exit_code: Some(ExitCode(0)),
             stdout: "stdout1".to_string(),
             stderr: "stderr1".to_string(),
         });
@@ -187,7 +187,7 @@ mod tests {
                 expected_exit_code: None,
                 expected_output: OutputExpectation::Any,
             },
-            exit_code: Some(0),
+            exit_code: Some(ExitCode(0)),
             stdout: "stdout2".to_string(),
             stderr: "stderr2".to_string(),
         });


### PR DESCRIPTION
- refactor: Make better use of ActionError in BasicPrinter
- refactor: Use ExitCode for returned exitcode
- refactor: Use match to tidy status printing
