### PR TITLE
  refactor: Fix warning when building on windows

### DIFF
--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -121,6 +121,7 @@ mod tests {
 
     mod shell {
         use super::{Error, Executor, ScriptCode, ShellExecutor};
+        #[cfg(not(windows))]
         use std::env;
         use std::path::PathBuf;
 


### PR DESCRIPTION
This import isn't used for windows