### PR TITLE
ci: Spot problems in disabled code

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -105,7 +105,12 @@ jobs:
         shell: bash
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/cache@v2.1.6
@@ -133,6 +138,7 @@ jobs:
           args: --all-targets --all-features -- -D warnings -Dclippy::all -D clippy::pedantic
             -D clippy::cargo -A clippy::multiple-crate-versions
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
+        if: matrix.os == 'ubuntu-latest'
 
   release:
     if: github.ref == 'refs/heads/master'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,8 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=lint
+      - status-success=lint (windows-latest)
+      - status-success=lint (ubuntu-latest)
       - status-success=versio-plan
       - status-success=cargo-test (ubuntu-latest)
       - status-success=cargo-test (macos-latest)
@@ -12,7 +13,8 @@ queue_rules:
 pull_request_rules:
   - name: automatic rebase for dependencies
     conditions:
-      - status-success=lint
+      - status-success=lint (windows-latest)
+      - status-success=lint (ubuntu-latest)
       - status-success=versio-plan
       - status-success=cargo-test (ubuntu-latest)
       - status-success=cargo-test (macos-latest)

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -121,6 +121,7 @@ mod tests {
 
     mod shell {
         use super::{Error, Executor, ScriptCode, ShellExecutor};
+        #[cfg(not(windows))]
         use std::env;
         use std::path::PathBuf;
 


### PR DESCRIPTION
Linters don't check cfg disabled code, leading to problems like #78
slipping through. This should spot those problems.
