### PR TITLE
docs: Use strip instead of run

### DIFF
--- a/docs/cli/display_help.md
+++ b/docs/cli/display_help.md
@@ -8,7 +8,7 @@ specdown
 
 Outputs:
 
-```,verify(script_name="with-no-args", stream=stderr)
+```,verify(stream=stderr)
 specdown 1.0.0
 A tool to test markdown files and drive devlopment from documentation.
 
@@ -32,33 +32,23 @@ SUBCOMMANDS:
 You can also run a specific sub-command with the `--help` argument for help on that sub-command.
 For example:
 
-```shell,script(name="run-with-help")
-specdown run --help
+```shell,script(name="strip-with-help")
+specdown strip --help
 ```
 
 Displays:
 
-```,verify(script_name="run-with-help")
-specdown-run 
-Runs a given Markdown Specification
+```,verify()
+specdown-strip 
+Outputs a version of the markdown with all specdown functions removed
 
 USAGE:
-    specdown run [FLAGS] [OPTIONS] <spec-files>...
+    specdown strip <spec-file>
 
 FLAGS:
-    -h, --help                       Prints help information
-        --temporary-workspace-dir    Create a temporary workspace directory
-    -V, --version                    Prints version information
-
-OPTIONS:
-        --add-path <add-path>...           Adds the given directory to PATH
-        --env <env>...                     Set an environment variable (format: 'VAR_NAME=value')
-        --shell-command <shell-command>    The shell command used to execute script blocks [default: bash -c]
-        --unset-env <unset-env>...         Unset an environment variable
-        --working-dir <working-dir>        The directory where commands will be executed. This is relative to the
-                                           workspace dir
-        --workspace-dir <workspace-dir>    Set the workspace directory
+    -h, --help       Prints help information
+    -V, --version    Prints version information
 
 ARGS:
-    <spec-files>...    The spec files to run
+    <spec-file>    The spec file to strip specdown functions from
 ```

--- a/docs/cli/display_help_windows.md
+++ b/docs/cli/display_help_windows.md
@@ -8,7 +8,7 @@ specdown
 
 Outputs:
 
-```,verify(script_name="with-no-args", stream=stderr)
+```,verify(stream=stderr)
 specdown 1.0.0
 A tool to test markdown files and drive devlopment from documentation.
 
@@ -32,33 +32,23 @@ SUBCOMMANDS:
 You can also run a specific sub-command with the `--help` argument for help on that sub-command.
 For example:
 
-```shell,script(name="run-with-help")
-specdown run --help
+```shell,script(name="strip-with-help")
+specdown strip --help
 ```
 
 Displays:
 
-```,verify(script_name="run-with-help")
-specdown.exe-run 
-Runs a given Markdown Specification
+```,verify()
+specdown.exe-strip 
+Outputs a version of the markdown with all specdown functions removed
 
 USAGE:
-    specdown.exe run [FLAGS] [OPTIONS] <spec-files>...
+    specdown.exe strip <spec-file>
 
 FLAGS:
-    -h, --help                       Prints help information
-        --temporary-workspace-dir    Create a temporary workspace directory
-    -V, --version                    Prints version information
-
-OPTIONS:
-        --add-path <add-path>...           Adds the given directory to PATH
-        --env <env>...                     Set an environment variable (format: 'VAR_NAME=value')
-        --shell-command <shell-command>    The shell command used to execute script blocks [default: bash -c]
-        --unset-env <unset-env>...         Unset an environment variable
-        --working-dir <working-dir>        The directory where commands will be executed. This is relative to the
-                                           workspace dir
-        --workspace-dir <workspace-dir>    Set the workspace directory
+    -h, --help       Prints help information
+    -V, --version    Prints version information
 
 ARGS:
-    <spec-files>...    The spec files to run
+    <spec-file>    The spec file to strip specdown functions from
 ```


### PR DESCRIPTION
The run command is changing fast of this file always needs updating but run is not necessary for the example. Using strip instead will be lower maintenance.
