### PR TITLE
feat: Add the ability to filter verifications by os

### DIFF
--- a/.versio.yaml
+++ b/.versio.yaml
@@ -14,6 +14,16 @@ projects:
             pattern: specdown (\d+\.\d+\.\d+)
           - file: docs/cli/display_help_windows.md
             pattern: specdown (\d+\.\d+\.\d+)
+          - file: docs/specs/verifying_script_output.md
+            pattern: specdown (\d+\.\d+\.\d+)
+          - file: docs/specs/verifying_script_output.md
+            pattern: specdown (\d+\.\d+\.\d+)
+          - file: docs/specs/verifying_script_output.md
+            pattern: specdown (\d+\.\d+\.\d+)
+          - file: docs/specs/verifying_script_output.md
+            pattern: specdown.exe (\d+\.\d+\.\d+)
+          - file: docs/specs/verifying_script_output.md
+            pattern: specdown.exe (\d+\.\d+\.\d+)
           - file: tests/command_test.rs
             pattern: specdown (\d+\.\d+\.\d+)
       hooks:

--- a/docs/specs/verifying_script_output.md
+++ b/docs/specs/verifying_script_output.md
@@ -37,7 +37,7 @@ When you run the following:
 specdown run verify_example.md
 ```
 
-The you will see the following output:
+Then you will see the following output:
 
 ```text,verify(script_name="verify_example")
 Running tests for verify_example.md:
@@ -96,7 +96,7 @@ When you run the following:
 specdown run omit_name_example.md
 ```
 
-The you will see the following output:
+Then you will see the following output:
 
 ```text,verify(script_name="omit_name_example")
 Running tests for omit_name_example.md:
@@ -107,5 +107,169 @@ Running tests for omit_name_example.md:
   ✓ verifying stdout from 'script_with_name' succeeded
 
   4 functions run (4 succeeded / 0 failed)
+
+```
+
+## Making OS Specific verifications
+
+An operating system can be specified for the verification to apply to. This is limited to the [values provided by rust](https://doc.rust-lang.org/std/env/consts/constant.OS.html)
+
+Given the file `os_specific.md`:
+
+~~~markdown,file(path="os_specific.md")
+# OS Specific verifiction
+
+Run a script with no name:
+
+```shell,script(name="os_specific")
+specdown -h
+```
+
+Verify the output:
+
+```text,verify(script_name="os_specific",target_os="windows")
+specdown 1.1.10
+A tool to test markdown files and drive devlopment from documentation.
+
+USAGE:
+    specdown.exe [FLAGS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help         Prints help information
+        --no-colour    Disables coloured output
+    -V, --version      Prints version information
+
+SUBCOMMANDS:
+    completion    Output completion for a shell of your choice
+    help          Prints this message or the help of the given subcommand(s)
+    run           Runs a given Markdown Specification
+    strip         Outputs a version of the markdown with all specdown functions removed
+```
+
+```text,verify(script_name="os_specific",target_os="linux")
+specdown 1.1.10
+A tool to test markdown files and drive devlopment from documentation.
+
+USAGE:
+    specdown [FLAGS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help         Prints help information
+        --no-colour    Disables coloured output
+    -V, --version      Prints version information
+
+SUBCOMMANDS:
+    completion    Output completion for a shell of your choice
+    help          Prints this message or the help of the given subcommand(s)
+    run           Runs a given Markdown Specification
+    strip         Outputs a version of the markdown with all specdown functions removed
+```
+
+```text,verify(script_name="os_specific",target_os="macos")
+specdown 1.1.10
+A tool to test markdown files and drive devlopment from documentation.
+
+USAGE:
+    specdown [FLAGS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help         Prints help information
+        --no-colour    Disables coloured output
+    -V, --version      Prints version information
+
+SUBCOMMANDS:
+    completion    Output completion for a shell of your choice
+    help          Prints this message or the help of the given subcommand(s)
+    run           Runs a given Markdown Specification
+    strip         Outputs a version of the markdown with all specdown functions removed
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="os_specific", expected_exit_code=0)
+specdown run os_specific.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="os_specific")
+Running tests for os_specific.md:
+
+  ✓ running script 'os_specific' succeeded
+  ✓ verifying stdout from 'os_specific' succeeded
+
+  2 functions run (2 succeeded / 0 failed)
+
+```
+
+You may also negate the target os
+Given the file `os_specific_negation.md`:
+
+~~~markdown,file(path="os_specific_negation.md")
+# OS Specific nagative verifiction
+
+Run a script with no name:
+
+```shell,script(name="os_specific_negation")
+specdown -h
+```
+
+Verify the output:
+
+```text,verify(script_name="os_specific_negation",target_os="!windows")
+specdown 1.1.10
+A tool to test markdown files and drive devlopment from documentation.
+
+USAGE:
+    specdown [FLAGS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help         Prints help information
+        --no-colour    Disables coloured output
+    -V, --version      Prints version information
+
+SUBCOMMANDS:
+    completion    Output completion for a shell of your choice
+    help          Prints this message or the help of the given subcommand(s)
+    run           Runs a given Markdown Specification
+    strip         Outputs a version of the markdown with all specdown functions removed
+```
+
+```text,verify(script_name="os_specific_negation",target_os="windows")
+specdown 1.1.10
+A tool to test markdown files and drive devlopment from documentation.
+
+USAGE:
+    specdown.exe [FLAGS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help         Prints help information
+        --no-colour    Disables coloured output
+    -V, --version      Prints version information
+
+SUBCOMMANDS:
+    completion    Output completion for a shell of your choice
+    help          Prints this message or the help of the given subcommand(s)
+    run           Runs a given Markdown Specification
+    strip         Outputs a version of the markdown with all specdown functions removed
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="os_specific_negation", expected_exit_code=0)
+specdown run os_specific_negation.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="os_specific_negation")
+Running tests for os_specific_negation.md:
+
+  ✓ running script 'os_specific_negation' succeeded
+  ✓ verifying stdout from 'os_specific_negation' succeeded
+
+  2 functions run (2 succeeded / 0 failed)
 
 ```

--- a/src/parser/actions.rs
+++ b/src/parser/actions.rs
@@ -1,8 +1,10 @@
 use super::code_block_info;
 use super::error::Result;
 use crate::types::{
-    Action, CreateFileAction, FileContent, ScriptAction, ScriptCode, VerifyAction, VerifyValue,
+    Action, CreateFileAction, FileContent, ScriptAction, ScriptCode, Source, TargetOs,
+    VerifyAction, VerifyValue,
 };
+use std::env::consts::OS;
 
 pub fn create_action(info: &str, literal: String) -> Result<Option<Action>> {
     let (_, block) = code_block_info::parse(info)?;
@@ -18,8 +20,28 @@ pub fn create_action(info: &str, literal: String) -> Result<Option<Action>> {
             expected_exit_code,
             expected_output,
         })),
-        code_block_info::CodeBlockType::Verify(source) => Some(Action::Verify(VerifyAction {
-            source,
+        code_block_info::CodeBlockType::Verify(Source {
+            target_os: None,
+            name,
+            stream,
+        }) => Some(Action::Verify(VerifyAction {
+            source: Source {
+                name,
+                stream,
+                target_os: None,
+            },
+            expected_value: VerifyValue(literal),
+        })),
+        code_block_info::CodeBlockType::Verify(Source {
+            target_os: Some(TargetOs(target_os)),
+            name,
+            stream,
+        }) if target_os_matches_current(&target_os) => Some(Action::Verify(VerifyAction {
+            source: Source {
+                name,
+                stream,
+                target_os: Some(TargetOs(target_os)),
+            },
             expected_value: VerifyValue(literal),
         })),
         code_block_info::CodeBlockType::CreateFile(file_path) => {
@@ -28,8 +50,21 @@ pub fn create_action(info: &str, literal: String) -> Result<Option<Action>> {
                 file_content: FileContent(literal),
             }))
         }
-        code_block_info::CodeBlockType::Skip() => None,
+        code_block_info::CodeBlockType::Skip()
+        | code_block_info::CodeBlockType::Verify(Source {
+            name: _,
+            stream: _,
+            target_os: Some(_),
+        }) => None,
     })
+}
+
+fn target_os_matches_current(target_os: &str) -> bool {
+    if target_os == OS {
+        return true;
+    }
+
+    target_os.starts_with('!') && target_os != format!("!{}", OS)
 }
 
 #[cfg(test)]
@@ -37,7 +72,7 @@ mod tests {
     use super::{create_action, Action, FileContent, ScriptCode, VerifyValue};
     use crate::types::{
         CreateFileAction, FilePath, OutputExpectation, ScriptAction, ScriptName, Source, Stream,
-        VerifyAction,
+        TargetOs, VerifyAction,
     };
 
     #[test]
@@ -58,14 +93,44 @@ mod tests {
         assert_eq!(
             create_action(
                 ",verify(script_name=\"script-name\", stream=stdout)",
-                "value".to_string()
+                "value".to_string(),
             ),
             Ok(Some(Action::Verify(VerifyAction {
                 source: Source {
                     name: Some(ScriptName("script-name".to_string())),
                     stream: Stream::StdOut,
+                    target_os: None,
                 },
-                expected_value: VerifyValue("value".to_string())
+                expected_value: VerifyValue("value".to_string()),
+            })))
+        );
+    }
+
+    #[test]
+    fn create_action_for_verify_that_is_skipped() {
+        assert_eq!(
+            create_action(
+                ",verify(script_name=\"script-name\", target_os=\"fake-os\")",
+                "value".to_string(),
+            ),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn create_action_for_verify_that_is_negated() {
+        assert_eq!(
+            create_action(
+                ",verify(script_name=\"script-name\", target_os=\"!fake-os\")",
+                "value".to_string(),
+            ),
+            Ok(Some(Action::Verify(VerifyAction {
+                source: Source {
+                    name: Some(ScriptName("script-name".to_string())),
+                    stream: Stream::StdOut,
+                    target_os: Some(TargetOs("!fake-os".to_string())),
+                },
+                expected_value: VerifyValue("value".to_string()),
             })))
         );
     }
@@ -76,7 +141,7 @@ mod tests {
             create_action(",file(path=\"file.txt\")", "content".to_string()),
             Ok(Some(Action::CreateFile(CreateFileAction {
                 file_path: FilePath("file.txt".to_string()),
-                file_content: FileContent("content".to_string())
+                file_content: FileContent("content".to_string()),
             })))
         );
     }

--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -267,6 +267,7 @@ mod tests {
                         source: Source {
                             name: Some(ScriptName("example_script".to_string())),
                             stream: Stream::StdOut,
+                            target_os: None,
                         },
                         expected_value: VerifyValue("the output".to_string()),
                     },
@@ -283,6 +284,7 @@ mod tests {
                         source: Source {
                             name: Some(ScriptName("example_script".to_string())),
                             stream: Stream::StdOut,
+                            target_os: None,
                         },
                         expected_value: VerifyValue("expected output".to_string()),
                     },

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -50,7 +50,7 @@ impl ShellExecutor {
         Self {
             command: command.first().unwrap().to_string(),
             args: Vec::from(args),
-            env: env.to_vec().into_iter().collect(),
+            env: env.iter().cloned().collect(),
             unset_env: unset_env.to_vec(),
             paths: paths.iter().map(PathBuf::from).collect(),
         }

--- a/src/runner/state.rs
+++ b/src/runner/state.rs
@@ -163,6 +163,7 @@ mod tests {
                 source: Source {
                     name: Some(ScriptName("script2".to_string())),
                     stream: Stream::StdOut,
+                    target_os: None,
                 },
                 expected_value: VerifyValue("expected".to_string()),
             },
@@ -180,6 +181,7 @@ mod tests {
                 source: Source {
                     name: Some(ScriptName("script2".to_string())),
                     stream: Stream::StdOut,
+                    target_os: None,
                 },
                 expected_value: VerifyValue("expected".to_string()),
             },
@@ -190,6 +192,7 @@ mod tests {
                 source: Source {
                     name: Some(ScriptName("script2".to_string())),
                     stream: Stream::StdOut,
+                    target_os: None,
                 },
                 expected_value: VerifyValue("expected".to_string()),
             },
@@ -208,6 +211,7 @@ mod tests {
                 source: Source {
                     name: Some(ScriptName("script2".to_string())),
                     stream: Stream::StdOut,
+                    target_os: None,
                 },
                 expected_value: VerifyValue("expected".to_string()),
             },

--- a/src/runner/verify.rs
+++ b/src/runner/verify.rs
@@ -6,7 +6,11 @@ use crate::types::{Source, Stream, VerifyAction};
 use super::Error;
 
 pub fn run(action: &VerifyAction, script_output: &dyn ScriptOutput) -> Result<ActionResult, Error> {
-    let Source { name, stream } = action.source.clone();
+    let Source {
+        name,
+        stream,
+        target_os: _,
+    } = action.source.clone();
 
     let result = name
         .as_ref()
@@ -109,6 +113,7 @@ mod tests {
             let source = Source {
                 name: None,
                 stream: Stream::StdOut,
+                target_os: None,
             };
             let verify_value = VerifyValue("hello world".to_string());
             let script_output = MockScriptOutput::with_unnamed_result("hello world", "");
@@ -132,6 +137,7 @@ mod tests {
             let source = Source {
                 name: None,
                 stream: Stream::StdOut,
+                target_os: None,
             };
             let verify_value = VerifyValue("hello world".to_string());
             let script_output = MockScriptOutput::with_result("example_script", "hello world", "");
@@ -155,6 +161,7 @@ mod tests {
             let source = Source {
                 name: None,
                 stream: Stream::StdErr,
+                target_os: None,
             };
             let verify_value = VerifyValue("hello world".to_string());
             let script_output = MockScriptOutput::with_result("example_script", "", "hello world");
@@ -178,6 +185,7 @@ mod tests {
             let source = Source {
                 name: Some(ScriptName("example_script".to_string())),
                 stream: Stream::StdOut,
+                target_os: None,
             };
             let verify_value = VerifyValue("hello world".to_string());
             let script_output = MockScriptOutput::with_result("example_script", "hello world", "");
@@ -201,6 +209,7 @@ mod tests {
             let source = Source {
                 name: Some(ScriptName("my_script".to_string())),
                 stream: Stream::StdErr,
+                target_os: None,
             };
             let verify_value = VerifyValue("error message".to_string());
             let script_output =
@@ -225,6 +234,7 @@ mod tests {
             let source = Source {
                 name: Some(ScriptName("missing_script".to_string())),
                 stream: Stream::StdErr,
+                target_os: None,
             };
             let verify_value = VerifyValue("error message".to_string());
             let script_output = MockScriptOutput::with_result("existing_script", "", "");
@@ -245,6 +255,7 @@ mod tests {
             let source = Source {
                 name: None,
                 stream: Stream::StdErr,
+                target_os: None,
             };
             let verify_value = VerifyValue("error message".to_string());
             let script_output = MockScriptOutput::without_result();
@@ -266,6 +277,7 @@ mod tests {
             let source = Source {
                 name: Some(ScriptName("colour_script".to_string())),
                 stream: Stream::StdOut,
+                target_os: None,
             };
             let verify_value = VerifyValue("\x1b[34mThis is coloured".to_string());
             let script_output =

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,9 @@ pub enum Stream {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct TargetOs(pub String);
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct ScriptName(pub String);
 
 impl From<ScriptName> for String {
@@ -25,6 +28,7 @@ impl From<&ScriptName> for String {
 pub struct Source {
     pub name: Option<ScriptName>,
     pub stream: Stream,
+    pub target_os: Option<TargetOs>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -98,6 +102,7 @@ impl VerifyAction {
             source: Source {
                 name: script_name,
                 stream: self.source.stream.clone(),
+                target_os: None,
             },
             expected_value: self.expected_value.clone(),
         }
@@ -189,6 +194,7 @@ mod tests {
                 source: Source {
                     name: None,
                     stream: Stream::StdOut,
+                    target_os: None,
                 },
                 expected_value: VerifyValue("".to_string()),
             };
@@ -197,7 +203,8 @@ mod tests {
                 VerifyAction {
                     source: Source {
                         name: Some(ScriptName("new_name".to_string())),
-                        stream: Stream::StdOut
+                        stream: Stream::StdOut,
+                        target_os: None
                     },
                     expected_value: VerifyValue("".to_string())
                 },


### PR DESCRIPTION
Sometimes it's desirable to run different verifications per operating
system. You can see this in this tools own markdown files with the
assorted windows variants of the tests. This will add support for
limiting a verification to a specfic OS.

Fixes: #115