### PR TITLE
build: Update versio pattern

### DIFF
--- a/.versio.yaml
+++ b/.versio.yaml
@@ -21,9 +21,9 @@ projects:
           - file: docs/specs/verifying_script_output.md
             pattern: specdown (\d+\.\d+\.\d+)
           - file: docs/specs/verifying_script_output.md
-            pattern: specdown.exe (\d+\.\d+\.\d+)
+            pattern: specdown (\d+\.\d+\.\d+)
           - file: docs/specs/verifying_script_output.md
-            pattern: specdown.exe (\d+\.\d+\.\d+)
+            pattern: specdown (\d+\.\d+\.\d+)
           - file: tests/command_test.rs
             pattern: specdown (\d+\.\d+\.\d+)
       hooks:


### PR DESCRIPTION
Currently the versio pattern for "verifying_script_output" is broken, and is breaking the release. This should fix that.

Note: I haven't tested this, Dry run doesn't seem to trigger these, which is frustrating, sorry about breaking the build