### PR TITLE
ci: Roll back markdown linter

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -137,7 +137,7 @@ jobs:
           command: clippy
           args: --all-targets --all-features -- -D warnings -Dclippy::all -D clippy::pedantic
             -D clippy::cargo -A clippy::multiple-crate-versions
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
         if: matrix.os == 'ubuntu-latest'
 
   release:


### PR DESCRIPTION
1.0.14 is a pre-release and breaks when checking anchor links.