### PR TITLE
fix: resolve lifetimes in function signatures warnings

### DIFF
--- a/src/parsers/function_string_parser/parser.rs
+++ b/src/parsers/function_string_parser/parser.rs
@@ -40,7 +40,7 @@ fn list_of_args_to_hash_map(arguments: &[Argument<'_>]) -> HashMap<String, Argum
         .collect()
 }
 
-fn argument<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Argument<'_>, E> {
+fn argument<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Argument<'a>, E> {
     let p = tuple((
         argument_name,
         tuple((space0, tag("="), space0)),
@@ -49,7 +49,7 @@ fn argument<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Argu
     map(p, |(name, _, value)| (name, value))(input)
 }
 
-fn argument_name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &str, E> {
+fn argument_name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
     let mut p = tuple((alpha1, many0(alt((alphanumeric1, tag("_"))))));
     let (remainder, (start, parts)) = p(input)?;
     let length = start.len() + parts.join("").len();

--- a/src/parsers/markdown/parser.rs
+++ b/src/parsers/markdown/parser.rs
@@ -24,7 +24,7 @@ fn extract_elements<'a>(root: &'a AstNode<'a>) -> Result<Vec<Element>, Error> {
     Ok(get_root_children(root)?.filter_map(to_element).collect())
 }
 
-fn get_root_children<'a>(root: &'a AstNode<'a>) -> Result<Children<'_, RefCell<Ast>>, Error> {
+fn get_root_children<'a>(root: &'a AstNode<'a>) -> Result<Children<'a, RefCell<Ast>>, Error> {
     match &root.data.borrow_mut().value {
         NodeValue::Document => Ok(root.children()),
         _ => Err(Error::RootMustBeDocument),


### PR DESCRIPTION
Adjusted lifetime annotations in function signatures to resolve compiler warnings.

Sample warning

```
warning: elided lifetime has a name
  --> src/parsers/function_string_parser/parser.rs:43:86
   |
43 | fn argument<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Argument<'_>, E> {
   |             -- lifetime `'a` declared here                                           ^^ this elided lifetime gets resolved as `'a`
   |
   = note: `#[warn(elided_named_lifetimes)
```