### PR TITLE
fix(ci): self-heal broken cargo shim after stale cache restore

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: v2
+      - name: Fix cargo shim if broken by stale cache
+        if: runner.os != 'Windows'
+        run: cargo --version >/dev/null 2>&1 || (rm -f ~/.cargo/bin/cargo && rustup default stable)
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
           cache-key: v2
       - name: Fix cargo shim if broken by stale cache
         if: runner.os != 'Windows'
-        run: cargo --version >/dev/null 2>&1 || (rm -f ~/.cargo/bin/cargo && rustup default stable)
+        run: cargo --version 2>&1 | grep -q '^cargo ' || (rm -f ~/.cargo/bin/cargo && rustup default stable)
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
## Summary

- Adds a self-healing step to the `cargo-test` CI job that detects and fixes a broken `~/.cargo/bin/cargo` shim after cache restore
- When the macOS runner image upgrades (e.g. macos-14 → macos-15), the first run creates a poisoned cache containing `rustup-init` at `~/.cargo/bin/cargo`; subsequent runs restore it and fail with `unexpected argument 'build' found`
- The fix checks if `cargo --version` works post-restore; if not, removes the broken binary and re-runs `rustup default stable` to recreate the shim

## Test plan

- [ ] All `cargo-test` jobs pass on macOS, Ubuntu, Windows
- [ ] Existing dependabot PRs (#502, #505, #508, #513) pass after rebasing onto this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)