### PR TITLE
fix(ci): use rustup update to recreate cargo proxy after cache poisoning

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
           cache-key: v2
       - name: Fix cargo shim if broken by stale cache
         if: runner.os != 'Windows'
-        run: cargo --version 2>&1 | grep -q '^cargo ' || (rm -f ~/.cargo/bin/cargo && rustup default stable)
+        run: cargo --version 2>&1 | grep -q '^cargo ' || (rm -f ~/.cargo/bin/cargo && rustup update stable --no-self-update)
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
           cache-key: v2
       - name: Fix cargo shim if broken by stale cache
         if: runner.os != 'Windows'
-        run: cargo --version 2>&1 | grep -q '^cargo ' || (rm -f ~/.cargo/bin/cargo && rustup update stable --no-self-update)
+        run: cargo --version 2>&1 | grep -q '^cargo ' || ln -sf "$(rustup which cargo)" ~/.cargo/bin/cargo
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
## Summary

- `rustup default stable` reports "unchanged" when the toolchain is already installed and does **not** recreate the `~/.cargo/bin/cargo` proxy binary after deletion
- After the self-healing step deletes the stale cargo shim, `cargo` is completely absent from PATH, causing `make test` to fail with `cargo: No such file or directory`
- `rustup update stable --no-self-update` forces reinstallation and always recreates the proxy binary

## Test plan

- [ ] macOS CI should pass on dependabot PRs that previously failed with `make: cargo: No such file or directory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)