### PR TITLE
fix: stop crash on fenced code blocks without a specdown function

### DIFF
--- a/src/parsers/code_block_info.rs
+++ b/src/parsers/code_block_info.rs
@@ -9,10 +9,10 @@ use crate::parsers::markdown::code_block_info;
 pub fn parse(input: &str) -> Result<CodeBlockInfo<CodeBlockType>> {
     match code_block_info::parse(code_block_type::parse).parse(input) {
         Ok((_, result)) => Ok(result),
-        Err(err) => match err {
-            Err::Incomplete(_) => panic!("code_block_info parser returned an Incomplete error"),
-            Err::Error(e) | Err::Failure(e) => Err(e),
-        },
+        Err(Err::Error(e) | Err::Failure(e)) => Err(e),
+        Err(Err::Incomplete(_)) => {
+            unreachable!("complete parsers never return Incomplete on finite &str input")
+        }
     }
 }
 
@@ -270,6 +270,19 @@ mod tests {
                         }
                     ))
                 );
+            }
+        }
+
+        mod no_specdown_function {
+            use crate::parsers::error::Error;
+
+            use super::parse;
+
+            #[test]
+            fn returns_an_error_when_there_is_no_comma_in_the_info_string() {
+                let result = parse("specdown");
+                assert!(result.is_err());
+                assert!(matches!(result, Err(Error::ParserFailed(_))));
             }
         }
 

--- a/src/parsers/function_string_parser/parser.rs
+++ b/src/parsers/function_string_parser/parser.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use nom::error::ParseError;
 use nom::{
     branch::alt,
-    bytes::streaming::{tag, take_until},
-    character::streaming::{alpha1, alphanumeric1, digit1, space0},
+    bytes::complete::{tag, take_until},
+    character::complete::{alpha1, alphanumeric1, digit1, space0},
     combinator::map,
     multi::{many0, separated_list0},
     sequence::delimited,
@@ -368,7 +368,6 @@ mod tests {
 
         mod string_value {
             use super::{argument_value, ArgumentValue};
-            use nom::Needed::Unknown;
 
             #[test]
             fn succeeds_when_there_is_a_remainder() {
@@ -393,7 +392,10 @@ mod tests {
             fn fails_when_there_is_no_closing_quote() {
                 assert_eq!(
                     argument_value::<nom::error::Error<&str>>("\"arg_value2"),
-                    Err(nom::Err::Incomplete(Unknown))
+                    Err(nom::Err::Error(nom::error::Error {
+                        input: "\"arg_value2",
+                        code: nom::error::ErrorKind::Alpha
+                    }))
                 );
             }
         }

--- a/src/parsers/markdown/code_block_info.rs
+++ b/src/parsers/markdown/code_block_info.rs
@@ -1,4 +1,4 @@
-use nom::bytes::streaming::{tag, take_until};
+use nom::bytes::complete::{tag, take_until};
 use nom::combinator::map;
 use nom::error::ParseError;
 use nom::sequence::separated_pair;
@@ -56,7 +56,13 @@ mod tests {
         fn failing_parsing_when_no_comma() {
             let result: IResult<&str, CodeBlockInfo<&str>, nom::error::Error<&str>> =
                 parse(rest).parse("rust");
-            assert_eq!(result, Err(nom::Err::Incomplete(nom::Needed::Unknown)));
+            assert_eq!(
+                result,
+                Err(nom::Err::Error(nom::error::Error {
+                    input: "rust",
+                    code: nom::error::ErrorKind::TakeUntil
+                }))
+            );
         }
 
         #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -25,8 +25,42 @@ pub fn parse(markdown: &str) -> Result<Vec<Action>> {
 fn to_action(element: &markdown::Element) -> Result<Option<Action>> {
     match element {
         markdown::Element::FencedCodeBlock { info, literal } => {
+            if !info.contains(',') {
+                return Ok(None);
+            }
             let code_block_type = code_block_info::parse(info)?.extra;
             Ok(actions::create_action(&code_block_type, literal.clone()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::parse;
+
+    #[test]
+    fn a_code_block_whose_info_string_is_not_a_specdown_function_is_ignored() {
+        let markdown = indoc! {r"
+            # Title
+
+            ```specdown
+            this is just a fenced block named specdown
+            ```
+        "};
+
+        assert_eq!(parse(markdown), Ok(vec![]));
+    }
+
+    #[test]
+    fn a_code_block_with_a_language_but_no_specdown_function_is_ignored() {
+        let markdown = indoc! {r"
+            ```rust
+            fn main() {}
+            ```
+        "};
+
+        assert_eq!(parse(markdown), Ok(vec![]));
     }
 }

--- a/src/parsers/strip.rs
+++ b/src/parsers/strip.rs
@@ -11,10 +11,9 @@ pub fn strip(markdown: &str) -> String {
     iter_nodes(root, &|node| {
         if let NodeValue::CodeBlock(ref mut block) = node.data.borrow_mut().value {
             let info_string = block.info.clone();
-            let language = code_block_info::parse(&info_string)
-                .expect("To parse codeblock info")
-                .language;
-            block.info = language;
+            if let Ok(parsed) = code_block_info::parse(&info_string) {
+                block.info = parsed.language;
+            }
         }
     });
 
@@ -64,6 +63,24 @@ mod tests {
             );
 
             assert_eq!(strip(markdown), expected.to_string());
+        }
+
+        #[test]
+        fn does_not_crash_when_a_code_block_has_no_specdown_function() {
+            let markdown = indoc! {r"
+                # Title
+
+                ```specdown
+                just a plain code block
+                ```
+            "};
+
+            let result = std::panic::catch_unwind(|| strip(markdown));
+            assert!(
+                result.is_ok(),
+                "strip panicked on a code block without a specdown function: {:?}",
+                result
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

A fenced code block whose info string has no comma (e.g. ` ```specdown ` or
` ```rust `) crashed specdown with a panic (exit 101) on both `run` and
`strip`.

### Root cause

The nom parsers used `streaming` combinators on a finite `&str` input.
Streaming parsers return `Err::Incomplete` at end-of-input when a delimiter
isn't found, because they can't tell whether more data is coming. On a
complete string that's semantically wrong — it should be a plain
`Err::Error`. The `Incomplete` variant was handled with a `panic!` in
`code_block_info::parse`, which fired on every plain code fence.

## Changes

**Commit 1 — `fix: use nom complete parsers for finite string input`**

Switches `bytes::streaming` / `character::streaming` to their `complete`
counterparts in both `function_string_parser` and `markdown::code_block_info`.
Replaces the `panic!` with `unreachable!` since complete parsers can no
longer return `Incomplete` on finite input. Updates the two tests that
asserted `Err::Incomplete` to assert `Err::Error` with the matching
`ErrorKind`.

**Commit 2 — `fix: skip non-specdown fenced code blocks instead of crashing`**

`to_action` now skips code blocks whose info string contains no comma, so
`run` treats plain code fences as ordinary documentation. `strip` leaves
blocks it cannot parse untouched instead of `.expect()`-ing success.

## Test plan

- [x] `make test` — 127 unit + 14 integration tests pass
- [x] `make check` — fmt + clippy pedantic + cargo check clean
- [x] `make build` — clean
- [x] Manual: ` ```specdown ` block → `run` exits 0, `strip` preserves verbatim
- [x] Manual: valid `shell,script(name="hello")` still runs correctly
- [x] Manual: `shell,unknownfn()` still reports "Unknown function" (exit 1)