### PR TITLE
fix: use nom complete parsers for finite string input

### DIFF
--- a/src/parsers/code_block_info.rs
+++ b/src/parsers/code_block_info.rs
@@ -9,10 +9,10 @@ use crate::parsers::markdown::code_block_info;
 pub fn parse(input: &str) -> Result<CodeBlockInfo<CodeBlockType>> {
     match code_block_info::parse(code_block_type::parse).parse(input) {
         Ok((_, result)) => Ok(result),
-        Err(err) => match err {
-            Err::Incomplete(_) => panic!("code_block_info parser returned an Incomplete error"),
-            Err::Error(e) | Err::Failure(e) => Err(e),
-        },
+        Err(Err::Error(e) | Err::Failure(e)) => Err(e),
+        Err(Err::Incomplete(_)) => {
+            unreachable!("complete parsers never return Incomplete on finite &str input")
+        }
     }
 }
 
@@ -270,6 +270,19 @@ mod tests {
                         }
                     ))
                 );
+            }
+        }
+
+        mod no_specdown_function {
+            use crate::parsers::error::Error;
+
+            use super::parse;
+
+            #[test]
+            fn returns_an_error_when_there_is_no_comma_in_the_info_string() {
+                let result = parse("specdown");
+                assert!(result.is_err());
+                assert!(matches!(result, Err(Error::ParserFailed(_))));
             }
         }
 

--- a/src/parsers/function_string_parser/parser.rs
+++ b/src/parsers/function_string_parser/parser.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use nom::error::ParseError;
 use nom::{
     branch::alt,
-    bytes::streaming::{tag, take_until},
-    character::streaming::{alpha1, alphanumeric1, digit1, space0},
+    bytes::complete::{tag, take_until},
+    character::complete::{alpha1, alphanumeric1, digit1, space0},
     combinator::map,
     multi::{many0, separated_list0},
     sequence::delimited,
@@ -368,7 +368,6 @@ mod tests {
 
         mod string_value {
             use super::{argument_value, ArgumentValue};
-            use nom::Needed::Unknown;
 
             #[test]
             fn succeeds_when_there_is_a_remainder() {
@@ -393,7 +392,10 @@ mod tests {
             fn fails_when_there_is_no_closing_quote() {
                 assert_eq!(
                     argument_value::<nom::error::Error<&str>>("\"arg_value2"),
-                    Err(nom::Err::Incomplete(Unknown))
+                    Err(nom::Err::Error(nom::error::Error {
+                        input: "\"arg_value2",
+                        code: nom::error::ErrorKind::Alpha
+                    }))
                 );
             }
         }

--- a/src/parsers/markdown/code_block_info.rs
+++ b/src/parsers/markdown/code_block_info.rs
@@ -1,4 +1,4 @@
-use nom::bytes::streaming::{tag, take_until};
+use nom::bytes::complete::{tag, take_until};
 use nom::combinator::map;
 use nom::error::ParseError;
 use nom::sequence::separated_pair;
@@ -56,7 +56,13 @@ mod tests {
         fn failing_parsing_when_no_comma() {
             let result: IResult<&str, CodeBlockInfo<&str>, nom::error::Error<&str>> =
                 parse(rest).parse("rust");
-            assert_eq!(result, Err(nom::Err::Incomplete(nom::Needed::Unknown)));
+            assert_eq!(
+                result,
+                Err(nom::Err::Error(nom::error::Error {
+                    input: "rust",
+                    code: nom::error::ErrorKind::TakeUntil
+                }))
+            );
         }
 
         #[test]


### PR DESCRIPTION
The info-string and function-string parsers used nom streaming combinators
on a finite &str. Streaming parsers return Err::Incomplete at end-of-input
when a delimiter is not found, because they cannot tell whether more data is
incoming. On a complete string that is semantically wrong: end-of-input
without the delimiter should be a plain Err::Error.

This was the cause of the panic on code blocks whose info string had no
comma (e.g. ```specdown): the streaming take_until(",") returned Incomplete
and code_block_info::parse panicked on it.

- Switch bytes/character::streaming to bytes/character::complete.
- Replace the panic with an unreachable! since complete parsers can no
  longer return Incomplete on finite input.
- Update the two tests asserting Incomplete to assert Error with the
  matching ErrorKind.