### PR TITLE
fix: skip non-specdown fenced code blocks instead of crashing

### DIFF
--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -25,8 +25,42 @@ pub fn parse(markdown: &str) -> Result<Vec<Action>> {
 fn to_action(element: &markdown::Element) -> Result<Option<Action>> {
     match element {
         markdown::Element::FencedCodeBlock { info, literal } => {
+            if !info.contains(',') {
+                return Ok(None);
+            }
             let code_block_type = code_block_info::parse(info)?.extra;
             Ok(actions::create_action(&code_block_type, literal.clone()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::parse;
+
+    #[test]
+    fn a_code_block_whose_info_string_is_not_a_specdown_function_is_ignored() {
+        let markdown = indoc! {r"
+            # Title
+
+            ```specdown
+            this is just a fenced block named specdown
+            ```
+        "};
+
+        assert_eq!(parse(markdown), Ok(vec![]));
+    }
+
+    #[test]
+    fn a_code_block_with_a_language_but_no_specdown_function_is_ignored() {
+        let markdown = indoc! {r"
+            ```rust
+            fn main() {}
+            ```
+        "};
+
+        assert_eq!(parse(markdown), Ok(vec![]));
     }
 }

--- a/src/parsers/strip.rs
+++ b/src/parsers/strip.rs
@@ -11,10 +11,9 @@ pub fn strip(markdown: &str) -> String {
     iter_nodes(root, &|node| {
         if let NodeValue::CodeBlock(ref mut block) = node.data.borrow_mut().value {
             let info_string = block.info.clone();
-            let language = code_block_info::parse(&info_string)
-                .expect("To parse codeblock info")
-                .language;
-            block.info = language;
+            if let Ok(parsed) = code_block_info::parse(&info_string) {
+                block.info = parsed.language;
+            }
         }
     });
 
@@ -64,6 +63,24 @@ mod tests {
             );
 
             assert_eq!(strip(markdown), expected.to_string());
+        }
+
+        #[test]
+        fn does_not_crash_when_a_code_block_has_no_specdown_function() {
+            let markdown = indoc! {r"
+                # Title
+
+                ```specdown
+                just a plain code block
+                ```
+            "};
+
+            let result = std::panic::catch_unwind(|| strip(markdown));
+            assert!(
+                result.is_ok(),
+                "strip panicked on a code block without a specdown function: {:?}",
+                result
+            );
         }
     }
 }


### PR DESCRIPTION
A fenced code block whose info string is not a specdown function (no comma,
e.g. ```specdown or ```rust) is ordinary documentation. With the parsers
now returning a clean error instead of panicking, treat that error as "not
a specdown block" and skip it:

- to_action skips blocks whose info string contains no comma, so `run`
  ignores plain code fences instead of reporting a parse error.
- strip leaves blocks it cannot parse untouched, instead of expecting
  success.