### PR TITLE
perf(parser): avoid heap allocations in hot parser paths

### DIFF
--- a/src/parsers/actions.rs
+++ b/src/parsers/actions.rs
@@ -72,7 +72,11 @@ fn target_os_matches_current(target_os: &str) -> bool {
         return true;
     }
 
-    target_os.starts_with('!') && target_os != format!("!{OS}")
+    let Some(negated) = target_os.strip_prefix('!') else {
+        return false;
+    };
+
+    negated != OS
 }
 
 #[cfg(test)]

--- a/src/parsers/function_string_parser/parser.rs
+++ b/src/parsers/function_string_parser/parser.rs
@@ -48,7 +48,7 @@ fn argument<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Argu
 fn argument_name<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
     let mut p = (alpha1, many0(alt((alphanumeric1, tag("_")))));
     let (remainder, (start, parts)) = p.parse(input)?;
-    let length = start.len() + parts.join("").len();
+    let length = start.len() + parts.iter().map(|p| (*p).len()).sum::<usize>();
     Ok((remainder, &input[0..length]))
 }
 


### PR DESCRIPTION
Two spots in the parser allocated a String only to immediately discard
it for a length or comparison:

- argument_name built parts.join("") just to call .len() on the result.
  Summing the slice lengths directly avoids the allocation entirely.
- target_os_matches_current formatted a String with format!("!{OS}")
  for a single equality check. Stripping the '!' prefix and comparing
  the remainder with == avoids the allocation.

Behaviour is unchanged.