### PR TITLE
refactor(results): combine redundant OutputExpectation::None checks

### DIFF
--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -35,11 +35,9 @@ impl ActionErrorProvider for ScriptResult {
             return Some(ActionError::UnexpectedOutputIsPresent(self.clone()));
         }
 
-        if self.action.expected_output == OutputExpectation::None && !self.stdout.is_empty() {
-            return Some(ActionError::UnexpectedOutputIsPresent(self.clone()));
-        }
-
-        if self.action.expected_output == OutputExpectation::None && !self.stderr.is_empty() {
+        if self.action.expected_output == OutputExpectation::None
+            && (!self.stdout.is_empty() || !self.stderr.is_empty())
+        {
             return Some(ActionError::UnexpectedOutputIsPresent(self.clone()));
         }
 


### PR DESCRIPTION
The ScriptResult error() method checked stdout and stderr separately for
the OutputExpectation::None case, producing two identical if-blocks.
Merge them into a single check with ||. Behaviour is unchanged and all
existing tests pass.

Mutation testing on this file (cargo-mutants) shows 0 missed mutants,
confirming the combined check is equally well-tested.