### PR TITLE
feat: add background scripts that are stopped at end of spec file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,5 @@ All documentation is written as SpecDown tests and form part of the test suite.
     - [Global Environment Variables](specs/global_environment_variables.md)
     - [Skipping Code Blocks](specs/skipping_code_blocks.md)
     - [Creating Test Files](specs/creating_test_files.md)
+    - [Background Scripts](specs/background_scripts.md)
 - [Errors](errors.md)

--- a/docs/specs/background_scripts.md
+++ b/docs/specs/background_scripts.md
@@ -1,0 +1,121 @@
+# Background Scripts
+
+Specifications can run scripts in the background that are automatically stopped
+at the end of the spec file. This is useful for starting servers or other
+long-running processes that subsequent scripts interact with.
+
+You start a background script using the `background` function.
+
+## Example
+
+Given the file `background_example.md`:
+
+~~~markdown,file(path="background_example.md")
+# Background Example
+
+Start a background server that listens for connections:
+
+```shell,background(name="server")
+while true; do
+  echo "server ready" > server_output.txt
+  sleep 60
+done
+```
+
+Wait for the server to be ready, then verify the output:
+
+```shell,script(name="check_server")
+sleep 1
+cat server_output.txt
+```
+
+```text,verify(script_name="check_server")
+server ready
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_example", expected_exit_code=0)
+specdown run background_example.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_example")
+Running tests for background_example.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ verifying stdout from 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  4 functions run (4 succeeded / 0 failed)
+
+```
+
+## Background scripts are stopped at the end of the spec
+
+Even if there are no more scripts after the background script starts, it will
+be stopped when the spec file completes.
+
+Given the file `background_stopped.md`:
+
+~~~markdown,file(path="background_stopped.md")
+# Background Stopped Example
+
+```shell,background(name="long_running")
+sleep 60
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_stopped", expected_exit_code=0)
+specdown run background_stopped.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_stopped")
+Running tests for background_stopped.md:
+
+  ✓ starting background script 'long_running' succeeded
+  ✓ stopping background script 'long_running' succeeded
+
+  2 functions run (2 succeeded / 0 failed)
+
+```
+
+## Background scripts without a name
+
+If you omit the `name` argument, the background script will be shown as
+`<unnamed>` in the output.
+
+Given the file `background_unnamed.md`:
+
+~~~markdown,file(path="background_unnamed.md")
+# Background Unnamed Example
+
+```shell,background()
+sleep 60
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_unnamed", expected_exit_code=0)
+specdown run background_unnamed.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_unnamed")
+Running tests for background_unnamed.md:
+
+  ✓ starting background script '<unnamed>' succeeded
+  ✓ stopping background script '<unnamed>' succeeded
+
+  2 functions run (2 succeeded / 0 failed)
+
+```

--- a/src/parsers/actions.rs
+++ b/src/parsers/actions.rs
@@ -1,7 +1,9 @@
-use crate::parsers::code_block_type::{BackgroundCodeBlock, CodeBlockType, ScriptCodeBlock, VerifyCodeBlock};
+use crate::parsers::code_block_type::{
+    BackgroundCodeBlock, CodeBlockType, ScriptCodeBlock, VerifyCodeBlock,
+};
 use crate::types::{
-    Action, BackgroundAction, CreateFileAction, FileContent, ScriptAction, ScriptCode, TargetOs, VerifyAction,
-    VerifyValue,
+    Action, BackgroundAction, CreateFileAction, FileContent, ScriptAction, ScriptCode, TargetOs,
+    VerifyAction, VerifyValue,
 };
 use std::env::consts::OS;
 
@@ -17,9 +19,9 @@ pub fn create_action(code_block_type: &CodeBlockType, literal: String) -> Option
             file_path: file_path.clone(),
             file_content: FileContent(literal),
         })),
-        CodeBlockType::Background(background_code_block) => {
-            Some(Action::Background(to_background_action(background_code_block, literal)))
-        }
+        CodeBlockType::Background(background_code_block) => Some(Action::Background(
+            to_background_action(background_code_block, literal),
+        )),
         CodeBlockType::Skip() => None,
     }
 }
@@ -78,9 +80,9 @@ mod tests {
     use super::{
         create_action, Action, CodeBlockType, FileContent, ScriptCode, ScriptCodeBlock, VerifyValue,
     };
-    use crate::types::BackgroundAction;
-    use crate::parsers::code_block_type::VerifyCodeBlock;
     use crate::parsers::code_block_type::BackgroundCodeBlock;
+    use crate::parsers::code_block_type::VerifyCodeBlock;
+    use crate::types::BackgroundAction;
     use crate::types::{
         CreateFileAction, FilePath, OutputExpectation, ScriptAction, ScriptName, Source, Stream,
         TargetOs, VerifyAction,
@@ -203,9 +205,7 @@ mod tests {
     fn create_action_for_background_without_name() {
         assert_eq!(
             create_action(
-                &CodeBlockType::Background(BackgroundCodeBlock {
-                    script_name: None,
-                }),
+                &CodeBlockType::Background(BackgroundCodeBlock { script_name: None }),
                 "code".to_string(),
             ),
             Some(Action::Background(BackgroundAction {

--- a/src/parsers/actions.rs
+++ b/src/parsers/actions.rs
@@ -1,6 +1,6 @@
-use crate::parsers::code_block_type::{CodeBlockType, ScriptCodeBlock, VerifyCodeBlock};
+use crate::parsers::code_block_type::{BackgroundCodeBlock, CodeBlockType, ScriptCodeBlock, VerifyCodeBlock};
 use crate::types::{
-    Action, CreateFileAction, FileContent, ScriptAction, ScriptCode, TargetOs, VerifyAction,
+    Action, BackgroundAction, CreateFileAction, FileContent, ScriptAction, ScriptCode, TargetOs, VerifyAction,
     VerifyValue,
 };
 use std::env::consts::OS;
@@ -17,6 +17,9 @@ pub fn create_action(code_block_type: &CodeBlockType, literal: String) -> Option
             file_path: file_path.clone(),
             file_content: FileContent(literal),
         })),
+        CodeBlockType::Background(background_code_block) => {
+            Some(Action::Background(to_background_action(background_code_block, literal)))
+        }
         CodeBlockType::Skip() => None,
     }
 }
@@ -33,6 +36,15 @@ fn to_script_action(code_block: &ScriptCodeBlock, literal: String) -> ScriptActi
         script_code: ScriptCode(literal),
         expected_exit_code: *expected_exit_code,
         expected_output: expected_output.clone(),
+    }
+}
+
+fn to_background_action(code_block: &BackgroundCodeBlock, literal: String) -> BackgroundAction {
+    let BackgroundCodeBlock { script_name } = code_block;
+
+    BackgroundAction {
+        script_name: script_name.clone(),
+        script_code: ScriptCode(literal),
     }
 }
 
@@ -66,7 +78,9 @@ mod tests {
     use super::{
         create_action, Action, CodeBlockType, FileContent, ScriptCode, ScriptCodeBlock, VerifyValue,
     };
+    use crate::types::BackgroundAction;
     use crate::parsers::code_block_type::VerifyCodeBlock;
+    use crate::parsers::code_block_type::BackgroundCodeBlock;
     use crate::types::{
         CreateFileAction, FilePath, OutputExpectation, ScriptAction, ScriptName, Source, Stream,
         TargetOs, VerifyAction,
@@ -165,6 +179,38 @@ mod tests {
             Some(Action::CreateFile(CreateFileAction {
                 file_path: FilePath("file.txt".to_string()),
                 file_content: FileContent("content".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_background() {
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: Some(ScriptName("bg-script".to_string())),
+                }),
+                "code".to_string(),
+            ),
+            Some(Action::Background(BackgroundAction {
+                script_name: Some(ScriptName("bg-script".to_string())),
+                script_code: ScriptCode("code".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_background_without_name() {
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: None,
+                }),
+                "code".to_string(),
+            ),
+            Some(Action::Background(BackgroundAction {
+                script_name: None,
+                script_code: ScriptCode("code".to_string()),
             }))
         );
     }

--- a/src/parsers/code_block_info.rs
+++ b/src/parsers/code_block_info.rs
@@ -346,9 +346,7 @@ mod tests {
                     result,
                     Ok(CodeBlockInfo {
                         language: "shell".to_string(),
-                        extra: CodeBlockType::Background(BackgroundCodeBlock {
-                            script_name: None,
-                        }),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock { script_name: None }),
                     })
                 );
             }

--- a/src/parsers/code_block_info.rs
+++ b/src/parsers/code_block_info.rs
@@ -318,5 +318,40 @@ mod tests {
                 );
             }
         }
+
+        mod background {
+            use crate::parsers::code_block_type::BackgroundCodeBlock;
+            use crate::types::ScriptName;
+
+            use super::{parse, CodeBlockInfo, CodeBlockType};
+
+            #[test]
+            fn succeeds_when_function_is_background_with_a_name() {
+                let result = parse("shell,background(name=\"server\")");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_without_a_name() {
+                let result = parse("shell,background()");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: None,
+                        }),
+                    })
+                );
+            }
+        }
     }
 }

--- a/src/parsers/code_block_type.rs
+++ b/src/parsers/code_block_type.rs
@@ -19,10 +19,16 @@ pub struct VerifyCodeBlock {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+pub struct BackgroundCodeBlock {
+    pub script_name: Option<ScriptName>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
 pub enum CodeBlockType {
     Script(ScriptCodeBlock),
     Verify(VerifyCodeBlock),
     CreateFile(FilePath),
+    Background(BackgroundCodeBlock),
     Skip(),
 }
 
@@ -35,6 +41,7 @@ fn from_function(f: Function) -> Result<CodeBlockType> {
         "script" => script_to_code_block_type(&f),
         "verify" => verify_to_code_block_type(&f),
         "file" => file_to_code_block_type(&f),
+        "background" => background_to_code_block_type(&f),
         "skip" => Ok(skip_to_code_block_type(&f)),
         _ => Err(Error::UnknownFunction(f.name)),
     }
@@ -80,6 +87,17 @@ fn to_expected_output(s: &str) -> Result<OutputExpectation> {
 fn file_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
     let path = f.get_string_argument("path")?;
     Ok(CodeBlockType::CreateFile(FilePath(path)))
+}
+
+fn background_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
+    let name = if f.has_argument("name") {
+        Some(ScriptName(f.get_string_argument("name")?))
+    } else {
+        None
+    };
+    Ok(CodeBlockType::Background(BackgroundCodeBlock {
+        script_name: name,
+    }))
 }
 
 const fn skip_to_code_block_type(_f: &Function) -> CodeBlockType {

--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -1,4 +1,7 @@
-use crate::types::{BackgroundAction, CreateFileAction, ExitCode, OutputExpectation, ScriptAction, ScriptName, VerifyAction};
+use crate::types::{
+    BackgroundAction, CreateFileAction, ExitCode, OutputExpectation, ScriptAction, ScriptName,
+    VerifyAction,
+};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum ActionError {

--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -1,4 +1,4 @@
-use crate::types::{CreateFileAction, ExitCode, OutputExpectation, ScriptAction, VerifyAction};
+use crate::types::{BackgroundAction, CreateFileAction, ExitCode, OutputExpectation, ScriptAction, ScriptName, VerifyAction};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum ActionError {
@@ -78,10 +78,34 @@ impl ActionErrorProvider for CreateFileResult {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BackgroundStartResult {
+    pub action: BackgroundAction,
+}
+
+impl ActionErrorProvider for BackgroundStartResult {
+    fn error(&self) -> Option<ActionError> {
+        None
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BackgroundStopResult {
+    pub script_name: Option<ScriptName>,
+}
+
+impl ActionErrorProvider for BackgroundStopResult {
+    fn error(&self) -> Option<ActionError> {
+        None
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ActionResult {
     Script(ScriptResult),
     Verify(VerifyResult),
     CreateFile(CreateFileResult),
+    BackgroundStart(BackgroundStartResult),
+    BackgroundStop(BackgroundStopResult),
 }
 
 impl ActionResult {
@@ -98,6 +122,8 @@ impl ActionResult {
             Self::Script(result) => result,
             Self::Verify(result) => result,
             Self::CreateFile(result) => result,
+            Self::BackgroundStart(result) => result,
+            Self::BackgroundStop(result) => result,
         }
     }
 }

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -9,7 +9,7 @@ use crate::runner::RunEvent;
 use crate::types::{ExitCode, OutputExpectation, Stream, VerifyAction};
 
 use super::action_result::ActionResult;
-use super::action_result::{ActionError, CreateFileResult, ScriptResult, VerifyResult};
+use super::action_result::{ActionError, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult, VerifyResult};
 use super::printer::Printer;
 
 struct Summary {
@@ -113,6 +113,23 @@ impl BasicPrinter {
             ),
             ActionResult::CreateFile(CreateFileResult { action, .. }) => {
                 format!("creating file {}", String::from(action.file_path.clone()))
+            }
+            ActionResult::BackgroundStart(BackgroundStartResult { action, .. }) => {
+                format!(
+                    "starting background script '{}'",
+                    action
+                        .script_name
+                        .clone()
+                        .map_or("<unnamed>".to_string(), Into::into)
+                )
+            }
+            ActionResult::BackgroundStop(BackgroundStopResult { script_name, .. }) => {
+                format!(
+                    "stopping background script '{}'",
+                    script_name
+                        .clone()
+                        .map_or("<unnamed>".to_string(), Into::into)
+                )
             }
         }
     }

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -9,7 +9,10 @@ use crate::runner::RunEvent;
 use crate::types::{ExitCode, OutputExpectation, Stream, VerifyAction};
 
 use super::action_result::ActionResult;
-use super::action_result::{ActionError, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult, VerifyResult};
+use super::action_result::{
+    ActionError, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult,
+    VerifyResult,
+};
 use super::printer::Printer;
 
 struct Summary {

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,4 +1,4 @@
-pub use action_result::{ActionResult, CreateFileResult, ScriptResult, VerifyResult};
+pub use action_result::{ActionResult, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult, VerifyResult};
 pub use printer::Printer;
 
 mod action_result;

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,4 +1,7 @@
-pub use action_result::{ActionResult, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult, VerifyResult};
+pub use action_result::{
+    ActionResult, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult,
+    VerifyResult,
+};
 pub use printer::Printer;
 
 mod action_result;

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,0 +1,35 @@
+use std::process::Child;
+
+use crate::results::{ActionResult, BackgroundStartResult};
+use crate::types::BackgroundAction;
+
+use super::executor::Executor;
+use super::Error;
+
+pub struct BackgroundProcess {
+    pub child: Child,
+    pub script_name: Option<crate::types::ScriptName>,
+}
+
+pub fn start(action: &BackgroundAction, executor: &dyn Executor) -> Result<(ActionResult, BackgroundProcess), Error> {
+    let BackgroundAction { script_name, script_code } = action;
+
+    let child = executor.spawn(script_code)?;
+
+    let result = ActionResult::BackgroundStart(BackgroundStartResult {
+        action: action.clone(),
+    });
+
+    Ok((result, BackgroundProcess {
+        child,
+        script_name: script_name.clone(),
+    }))
+}
+
+pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
+    let _ = bg.child.kill();
+    let _ = bg.child.wait();
+    ActionResult::BackgroundStop(crate::results::BackgroundStopResult {
+        script_name: bg.script_name,
+    })
+}

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,10 +1,3 @@
-//! Background script support for specdown.
-//!
-//! This is the first step towards having HTTP request testing in specdown.
-//! Background scripts allow starting a server or service that subsequent
-//! script blocks can interact with (e.g. via curl). Future work could
-//! build on this to provide first-class HTTP request/response assertions.
-
 use std::process::Child;
 
 use crate::results::{ActionResult, BackgroundStartResult};

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -11,8 +11,14 @@ pub struct BackgroundProcess {
     pub script_name: Option<crate::types::ScriptName>,
 }
 
-pub fn start(action: &BackgroundAction, executor: &dyn Executor) -> Result<(ActionResult, BackgroundProcess), Error> {
-    let BackgroundAction { script_name, script_code } = action;
+pub fn start(
+    action: &BackgroundAction,
+    executor: &dyn Executor,
+) -> Result<(ActionResult, BackgroundProcess), Error> {
+    let BackgroundAction {
+        script_name,
+        script_code,
+    } = action;
 
     let child = executor.spawn(script_code)?;
 
@@ -20,10 +26,13 @@ pub fn start(action: &BackgroundAction, executor: &dyn Executor) -> Result<(Acti
         action: action.clone(),
     });
 
-    Ok((result, BackgroundProcess {
-        child,
-        script_name: script_name.clone(),
-    }))
+    Ok((
+        result,
+        BackgroundProcess {
+            child,
+            script_name: script_name.clone(),
+        },
+    ))
 }
 
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,3 +1,10 @@
+//! Background script support for specdown.
+//!
+//! This is the first step towards having HTTP request testing in specdown.
+//! Background scripts allow starting a server or service that subsequent
+//! script blocks can interact with (e.g. via curl). Future work could
+//! build on this to provide first-class HTTP request/response assertions.
+
 use std::process::Child;
 
 use crate::results::{ActionResult, BackgroundStartResult};

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -10,4 +10,8 @@ pub enum Error {
     ScriptOutputMissing { missing_script_name: String },
     #[error("Invalid shell command provided: {command} (Error: {message})")]
     BadShellCommand { command: String, message: String },
+    #[error("Background scripts are not supported with this executor")]
+    BackgroundNotSupported,
+    #[error("Failed to spawn background process: {message}")]
+    SpawnFailed { message: String },
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -1,3 +1,5 @@
+use std::process::Child;
+
 use crate::types::ScriptCode;
 
 use super::Error;
@@ -24,4 +26,9 @@ impl From<std::process::Output> for Output {
 
 pub trait Executor {
     fn execute(&self, script: &ScriptCode) -> Result<Output, Error>;
+
+    fn spawn(&self, script: &ScriptCode) -> Result<Child, Error> {
+        let _ = script;
+        Err(Error::BackgroundNotSupported)
+    }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6,6 +6,7 @@ pub use state::State;
 
 use crate::types::Action;
 
+mod background;
 mod error;
 mod executor;
 mod file;
@@ -19,28 +20,56 @@ mod verify;
 pub struct Runner<'a> {
     executor: &'a dyn Executor,
     state: &'a mut State,
+    background_processes: Vec<background::BackgroundProcess>,
 }
 
 impl<'a> Runner<'a> {
     pub fn create(executor: &'a dyn Executor, state: &'a mut State) -> Self {
-        Runner { executor, state }
+        Runner {
+            executor,
+            state,
+            background_processes: Vec::new(),
+        }
     }
 
     pub fn run(&mut self, actions: &[Action]) -> Vec<RunEvent> {
-        actions
+        let mut events: Vec<RunEvent> = actions
             .iter()
             .map(|action| self.run_action(action))
-            .collect()
+            .collect();
+
+        // Stop all background processes
+        for bg in self.background_processes.drain(..) {
+            let result = background::stop(bg);
+            self.state.add_result(&result);
+            events.push(RunEvent::TestCompleted(result));
+        }
+
+        events
     }
 
     fn run_action(&mut self, action: &Action) -> RunEvent {
-        to_runnable(action)
-            .run(self.state, self.executor)
-            .map(|result| {
-                self.state.add_result(&result);
-                RunEvent::TestCompleted(result)
-            })
-            .or_else::<Error, _>(|error| Ok(RunEvent::ErrorOccurred(error)))
-            .unwrap()
+        match action {
+            Action::Background(bg_action) => {
+                match background::start(bg_action, self.executor) {
+                    Ok((result, bg_process)) => {
+                        self.state.add_result(&result);
+                        self.background_processes.push(bg_process);
+                        RunEvent::TestCompleted(result)
+                    }
+                    Err(error) => RunEvent::ErrorOccurred(error),
+                }
+            }
+            _ => {
+                to_runnable(action)
+                    .run(self.state, self.executor)
+                    .map(|result| {
+                        self.state.add_result(&result);
+                        RunEvent::TestCompleted(result)
+                    })
+                    .or_else::<Error, _>(|error| Ok(RunEvent::ErrorOccurred(error)))
+                    .unwrap()
+            }
+        }
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -50,26 +50,22 @@ impl<'a> Runner<'a> {
 
     fn run_action(&mut self, action: &Action) -> RunEvent {
         match action {
-            Action::Background(bg_action) => {
-                match background::start(bg_action, self.executor) {
-                    Ok((result, bg_process)) => {
-                        self.state.add_result(&result);
-                        self.background_processes.push(bg_process);
-                        RunEvent::TestCompleted(result)
-                    }
-                    Err(error) => RunEvent::ErrorOccurred(error),
+            Action::Background(bg_action) => match background::start(bg_action, self.executor) {
+                Ok((result, bg_process)) => {
+                    self.state.add_result(&result);
+                    self.background_processes.push(bg_process);
+                    RunEvent::TestCompleted(result)
                 }
-            }
-            _ => {
-                to_runnable(action)
-                    .run(self.state, self.executor)
-                    .map(|result| {
-                        self.state.add_result(&result);
-                        RunEvent::TestCompleted(result)
-                    })
-                    .or_else::<Error, _>(|error| Ok(RunEvent::ErrorOccurred(error)))
-                    .unwrap()
-            }
+                Err(error) => RunEvent::ErrorOccurred(error),
+            },
+            _ => to_runnable(action)
+                .run(self.state, self.executor)
+                .map(|result| {
+                    self.state.add_result(&result);
+                    RunEvent::TestCompleted(result)
+                })
+                .or_else::<Error, _>(|error| Ok(RunEvent::ErrorOccurred(error)))
+                .unwrap(),
         }
     }
 }

--- a/src/runner/runnable_action.rs
+++ b/src/runner/runnable_action.rs
@@ -1,5 +1,5 @@
 use crate::results::ActionResult;
-use crate::types::{Action, CreateFileAction, ScriptAction, VerifyAction};
+use crate::types::{Action, BackgroundAction, CreateFileAction, ScriptAction, VerifyAction};
 
 use super::{error, file, script, verify, Error, Executor, State};
 
@@ -8,6 +8,7 @@ pub fn to_runnable(action: &Action) -> &dyn RunnableAction {
         Action::Script(a) => a,
         Action::Verify(a) => a,
         Action::CreateFile(a) => a,
+        Action::Background(a) => a,
     }
 }
 
@@ -30,5 +31,14 @@ impl RunnableAction for VerifyAction {
 impl RunnableAction for CreateFileAction {
     fn run(&self, _state: &State, _executor: &dyn Executor) -> Result<ActionResult, Error> {
         Ok(file::run(self))
+    }
+}
+
+impl RunnableAction for BackgroundAction {
+    fn run(&self, _state: &State, _executor: &dyn Executor) -> Result<ActionResult, Error> {
+        // Background actions are handled specially by the Runner,
+        // not through the normal RunnableAction trait.
+        // This implementation should not be reached.
+        Err(Error::BackgroundNotSupported)
     }
 }

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -84,25 +84,31 @@ impl ShellExecutor {
 
         env::join_paths(paths)
     }
-}
 
-impl Executor for ShellExecutor {
-    fn execute(&self, script: &ScriptCode) -> Result<Output, Error> {
-        let ScriptCode(code_string) = script;
-
+    pub fn build_command(&self, code: &str) -> Command {
         let path = self.path_env_var();
 
         let mut command = Command::new(&self.command);
 
         command
             .args(&self.args)
-            .arg(code_string)
+            .arg(code)
             .envs(&self.env)
             .env("PATH", path.expect("Failed to construct PATH"));
 
         for name in &self.unset_env {
             command.env_remove(name);
         }
+
+        command
+    }
+}
+
+impl Executor for ShellExecutor {
+    fn execute(&self, script: &ScriptCode) -> Result<Output, Error> {
+        let ScriptCode(code_string) = script;
+
+        let mut command = self.build_command(code_string);
 
         let output = command.output();
 
@@ -112,6 +118,18 @@ impl Executor for ShellExecutor {
                 command: format!("{} {:?}", self.command, self.args),
                 message: err.to_string(),
             })
+    }
+
+    fn spawn(&self, script: &ScriptCode) -> Result<std::process::Child, Error> {
+        let ScriptCode(code_string) = script;
+
+        let mut command = self.build_command(code_string);
+        command.stdout(std::process::Stdio::null());
+        command.stderr(std::process::Stdio::null());
+
+        command.spawn().map_err(|err| Error::SpawnFailed {
+            message: err.to_string(),
+        })
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,11 +113,18 @@ pub struct CreateFileAction {
     pub file_content: FileContent,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BackgroundAction {
+    pub script_name: Option<ScriptName>,
+    pub script_code: ScriptCode,
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum Action {
     Script(ScriptAction),
     Verify(VerifyAction),
     CreateFile(CreateFileAction),
+    Background(BackgroundAction),
 }
 
 #[cfg(test)]

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -175,6 +175,24 @@ fn test_doc_stripping_specs() {
 }
 
 #[test]
+fn test_doc_background_scripts() {
+    let bin_dir = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("debug");
+    let result = Command::cargo_bin("specdown")
+        .unwrap()
+        .arg("run")
+        .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(bin_dir.to_str().unwrap())
+        .arg("docs/specs/background_scripts.md")
+        .ok();
+
+    assert_ok(&result);
+}
+
+#[test]
 fn test_displays_error_when_required_args_are_missing() {
     #[cfg(windows)]
     const BINARY_NAME: &str = "specdown.exe";


### PR DESCRIPTION
## Summary

Add a new `background(name=...)` code block type that starts a shell script as a background process. The process is automatically killed when the spec file completes, making it easy to test interactions with long-running services like servers.

## Usage

```markdown
```shell,background(name="server")
while true; do
  echo "server ready" > server_output.txt
  sleep 60
done
```

```shell,script(name="check_server")
sleep 1
cat server_output.txt
```

```text,verify(script_name="check_server")
server ready
```
```

The background process is automatically stopped at the end of the spec file. The output shows:

```
  ✓ starting background script 'server' succeeded
  ✓ running script 'check_server' succeeded
  ✓ verifying stdout from 'check_server' succeeded
  ✓ stopping background script 'server' succeeded
```

## Changes

- **New `background` code block parser** — parses `background(name=...)` with optional name argument
- **New `BackgroundAction` type** and `BackgroundStartResult` / `BackgroundStopResult` result types
- **`spawn` method on `Executor` trait** — default returns `BackgroundNotSupported`; `ShellExecutor` implements it using `Command::spawn()`
- **Runner tracks background processes** — kills them when the spec file completes
- **Printer shows start/stop events** with checkmarks in the output
- **Full specdown acceptance tests** in `docs/specs/background_scripts.md`

## Test Plan

- [x] All 127 unit tests pass
- [x] All 15 integration tests pass (including new `test_doc_background_scripts`)
- [x] `cargo build` with no warnings
- [x] Specdown acceptance tests verify: named background, unnamed background, auto-stop at end of spec