### PR TITLE
feat: detect background script exit codes and report crashes

### DIFF
--- a/docs/specs/background_scripts.md
+++ b/docs/specs/background_scripts.md
@@ -119,3 +119,114 @@ Running tests for background_unnamed.md:
   2 functions run (2 succeeded / 0 failed)
 
 ```
+
+## Background script that exits before the spec file ends
+
+If a background script exits on its own (with a zero exit code) before the spec
+file ends, specdown detects the early exit and reports it as succeeded. The
+process is not killed because it has already exited.
+
+Given the file `background_exits.md`:
+
+~~~markdown,file(path="background_exits.md")
+# Background Exits Example
+
+```shell,background(name="quick_exit")
+echo "done"
+```
+
+```shell,script(name="check_exit")
+sleep 1
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_exits", expected_exit_code=0)
+specdown run background_exits.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_exits")
+Running tests for background_exits.md:
+
+  ✓ starting background script 'quick_exit' succeeded
+  ✓ running script 'check_exit' succeeded
+  ✓ stopping background script 'quick_exit' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
+
+```
+
+## Background script that exits with a non-zero exit code
+
+If a background script exits on its own with a non-zero exit code before the
+spec file ends, specdown detects the crash and reports the stop as failed.
+
+Given the file `background_crash.md`:
+
+~~~markdown,file(path="background_crash.md")
+# Background Crash Example
+
+```shell,background(name="crashing")
+exit 1
+```
+
+```shell,script(name="check_crash")
+sleep 1
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_crash", expected_exit_code=1)
+specdown run background_crash.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_crash")
+Running tests for background_crash.md:
+
+  ✓ starting background script 'crashing' succeeded
+  ✓ running script 'check_crash' succeeded
+  ✗ stopping background script 'crashing' failed (exited with code 1)
+
+  3 functions run (2 succeeded / 1 failed)
+
+```
+
+## Background script that is still running at spec end
+
+If a background script is still running when the spec file ends, specdown kills
+the process and reports the stop as succeeded. This is the expected behavior for
+long-running processes like servers.
+
+Given the file `background_killed.md`:
+
+~~~markdown,file(path="background_killed.md")
+# Background Killed Example
+
+```shell,background(name="long_running")
+sleep 60
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_killed", expected_exit_code=0)
+specdown run background_killed.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_killed")
+Running tests for background_killed.md:
+
+  ✓ starting background script 'long_running' succeeded
+  ✓ stopping background script 'long_running' succeeded
+
+  2 functions run (2 succeeded / 0 failed)
+
+```

--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -8,6 +8,7 @@ pub enum ActionError {
     ExitCodeIsIncorrect(ScriptResult),
     UnexpectedOutputIsPresent(ScriptResult),
     OutputDoesNotMatch(VerifyResult),
+    BackgroundExitedWithError(BackgroundStopResult),
 }
 
 trait ActionErrorProvider {
@@ -94,12 +95,27 @@ impl ActionErrorProvider for BackgroundStartResult {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BackgroundStopResult {
     pub script_name: Option<ScriptName>,
+    pub exit_status: BackgroundExitStatus,
 }
 
 impl ActionErrorProvider for BackgroundStopResult {
     fn error(&self) -> Option<ActionError> {
-        None
+        match self.exit_status {
+            BackgroundExitStatus::Exited(code) if i32::from(code) != 0 => {
+                Some(ActionError::BackgroundExitedWithError(self.clone()))
+            }
+            _ => None,
+        }
     }
+}
+
+/// How a background process ended.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BackgroundExitStatus {
+    /// The process was still running and specdown killed it.
+    Killed,
+    /// The process exited on its own with the given exit code.
+    Exited(ExitCode),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -133,10 +149,16 @@ impl ActionResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{ActionError, ActionResult, CreateFileResult, ScriptResult, VerifyResult};
+    use super::{
+        ActionError, ActionResult, BackgroundExitStatus, BackgroundStopResult, CreateFileResult,
+        ScriptResult, VerifyResult,
+    };
 
     mod success {
-        use super::{ActionError, ActionResult, CreateFileResult, ScriptResult, VerifyResult};
+        use super::{
+            ActionError, ActionResult, BackgroundExitStatus, BackgroundStopResult,
+            CreateFileResult, ScriptResult, VerifyResult,
+        };
 
         mod error {
             use super::{ActionError, ActionResult, ScriptResult};
@@ -340,6 +362,59 @@ mod tests {
                     },
                 });
                 assert!(result.success());
+            }
+        }
+
+        mod background_stop {
+            use super::{ActionError, ActionResult, BackgroundExitStatus, BackgroundStopResult};
+            use crate::types::{ExitCode, ScriptName};
+
+            #[test]
+            fn returns_none_when_process_was_killed() {
+                let result = ActionResult::BackgroundStop(BackgroundStopResult {
+                    script_name: Some(ScriptName("server".to_string())),
+                    exit_status: BackgroundExitStatus::Killed,
+                });
+                assert_eq!(result.error(), None);
+                assert!(result.success());
+            }
+
+            #[test]
+            fn returns_none_when_process_exited_with_zero() {
+                let result = ActionResult::BackgroundStop(BackgroundStopResult {
+                    script_name: Some(ScriptName("server".to_string())),
+                    exit_status: BackgroundExitStatus::Exited(ExitCode(0)),
+                });
+                assert_eq!(result.error(), None);
+                assert!(result.success());
+            }
+
+            #[test]
+            fn returns_error_when_process_exited_with_non_zero() {
+                let stop_result = BackgroundStopResult {
+                    script_name: Some(ScriptName("server".to_string())),
+                    exit_status: BackgroundExitStatus::Exited(ExitCode(1)),
+                };
+                let result = ActionResult::BackgroundStop(stop_result.clone());
+                assert_eq!(
+                    result.error(),
+                    Some(ActionError::BackgroundExitedWithError(stop_result))
+                );
+                assert!(!result.success());
+            }
+
+            #[test]
+            fn returns_error_when_process_exited_with_signal_code() {
+                let stop_result = BackgroundStopResult {
+                    script_name: None,
+                    exit_status: BackgroundExitStatus::Exited(ExitCode(134)),
+                };
+                let result = ActionResult::BackgroundStop(stop_result.clone());
+                assert_eq!(
+                    result.error(),
+                    Some(ActionError::BackgroundExitedWithError(stop_result))
+                );
+                assert!(!result.success());
             }
         }
     }

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -10,8 +10,8 @@ use crate::types::{ExitCode, OutputExpectation, Stream, VerifyAction};
 
 use super::action_result::ActionResult;
 use super::action_result::{
-    ActionError, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult,
-    VerifyResult,
+    ActionError, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
+    CreateFileResult, ScriptResult, VerifyResult,
 };
 use super::printer::Printer;
 
@@ -166,6 +166,12 @@ impl BasicPrinter {
                 )
             }
             Some(ActionError::OutputDoesNotMatch(_)) => "failed".to_string(),
+            Some(ActionError::BackgroundExitedWithError(result)) => match result.exit_status {
+                BackgroundExitStatus::Exited(code) => {
+                    format!("failed (exited with code {})", i32::from(code))
+                }
+                BackgroundExitStatus::Killed => "succeeded".to_string(),
+            },
             None => "succeeded".to_string(),
         }
     }
@@ -189,6 +195,7 @@ impl BasicPrinter {
             }) => {
                 self.display_diff(&String::from(expected_value.clone()), got);
             }
+            ActionError::BackgroundExitedWithError(_) => {}
         }
     }
 

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,6 +1,6 @@
 pub use action_result::{
-    ActionResult, BackgroundStartResult, BackgroundStopResult, CreateFileResult, ScriptResult,
-    VerifyResult,
+    ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
+    CreateFileResult, ScriptResult, VerifyResult,
 };
 pub use printer::Printer;
 

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,7 +1,10 @@
 use std::process::Child;
 
-use crate::results::{ActionResult, BackgroundStartResult};
+use crate::results::{
+    ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
+};
 use crate::types::BackgroundAction;
+use crate::types::ExitCode;
 
 use super::executor::Executor;
 use super::Error;
@@ -36,9 +39,33 @@ pub fn start(
 }
 
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
-    let _ = bg.child.kill();
-    let _ = bg.child.wait();
-    ActionResult::BackgroundStop(crate::results::BackgroundStopResult {
-        script_name: bg.script_name,
-    })
+    // Check if the process has already exited on its own.
+    match bg.child.try_wait() {
+        Ok(Some(status)) => {
+            // The process exited before we could kill it.
+            let exit_code = status.code().unwrap_or(-1);
+            ActionResult::BackgroundStop(BackgroundStopResult {
+                script_name: bg.script_name,
+                exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
+            })
+        }
+        Ok(None) => {
+            // The process is still running — kill it and wait for it to exit.
+            let _ = bg.child.kill();
+            let _ = bg.child.wait();
+            ActionResult::BackgroundStop(BackgroundStopResult {
+                script_name: bg.script_name,
+                exit_status: BackgroundExitStatus::Killed,
+            })
+        }
+        Err(_) => {
+            // Could not determine the process status — kill it as a fallback.
+            let _ = bg.child.kill();
+            let _ = bg.child.wait();
+            ActionResult::BackgroundStop(BackgroundStopResult {
+                script_name: bg.script_name,
+                exit_status: BackgroundExitStatus::Killed,
+            })
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Background scripts that exit on their own are now distinguished from those that are killed by specdown at spec end. If a background process exits with a non-zero exit code before the spec file ends, the stop result is reported as failed with the exit code. If the process is still running, it is killed as before and reported as succeeded.

This defines and tests the three edge cases from #580:
1. **Background exits 0 early** — detected via `try_wait()`, reported as succeeded
2. **Background exits non-zero early** — detected via `try_wait()`, reported as failed with exit code
3. **Background still running at spec end** — killed as before, reported as succeeded

## Changes

- `BackgroundExitStatus` enum (`Killed` / `Exited(code)`) to distinguish how a background process ended
- `BackgroundStopResult` now carries `exit_status`
- `ActionError::BackgroundExitedWithError` variant for non-zero exits
- `background::stop()` uses `try_wait()` to check if the process already exited before killing
- Printer shows `failed (exited with code N)` for crashed background scripts
- Acceptance tests in `docs/specs/background_scripts.md` for all three edge cases
- Unit tests for the error detection logic

## Test Plan

- [x] `cargo test` — 135 unit tests pass (4 new)
- [x] `cargo test` — 15 integration tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] Specdown acceptance tests pass with `--add-path target/debug`

Closes #580