### PR TITLE
feat: add container executor using Docker socket API

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,17 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
-      - name: "workaround: Clear cached wrong-arch rustup bin"
-        if: runner.os != 'Windows'
-        shell: bash
-        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
-      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v5
+        name: Cache cargo dependencies
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            .cache
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
       - name: Audit check cargo packages
@@ -40,17 +46,17 @@ jobs:
         run: |
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           brew --prefix rustup 2>/dev/null && echo "$(brew --prefix rustup)/bin" >> $GITHUB_PATH || true
-      - name: "workaround: Remove cached x86_64 rustup from PATH on ARM Linux"
-        if: runner.arch == 'ARM64' && runner.os == 'Linux'
-        shell: bash
-        run: |
-          CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
-          echo "PATH=$CLEAN_PATH" >> $GITHUB_ENV
-      - name: "workaround: Clear cached wrong-arch rustup bin"
-        if: runner.os != 'Windows'
-        shell: bash
-        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
-      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v5
+        name: Cache cargo dependencies
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            .cache
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |
@@ -67,13 +73,19 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
     steps:
-      - name: "workaround: Clear cached wrong-arch rustup bin"
-        if: runner.os != 'Windows'
-        shell: bash
-        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
-      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v5
+        name: Cache cargo dependencies
         with:
-          rust-components: rustfmt, clippy
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            .cache
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
       - name: Run checks
         run: make check
       - name: Check markdown links

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,10 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
+      - name: "workaround: Clear cached wrong-arch rustup bin"
+        if: runner.os != 'Windows'
+        shell: bash
+        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
       - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
@@ -42,6 +46,10 @@ jobs:
         run: |
           CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
           echo "PATH=$CLEAN_PATH" >> $GITHUB_ENV
+      - name: "workaround: Clear cached wrong-arch rustup bin"
+        if: runner.os != 'Windows'
+        shell: bash
+        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
       - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
       - name: Rename wsl bash
         if: runner.os == 'Windows'
@@ -59,6 +67,10 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
     steps:
+      - name: "workaround: Clear cached wrong-arch rustup bin"
+        if: runner.os != 'Windows'
+        shell: bash
+        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
       - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
         with:
           rust-components: rustfmt, clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,10 +90,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -99,6 +120,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "caseless"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,10 +207,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -220,6 +328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,12 +363,32 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -270,9 +404,9 @@ checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -280,13 +414,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "env_filter",
  "log",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -305,10 +445,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -335,6 +541,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +563,278 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -362,22 +852,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jetscii"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
-name = "libc"
-version = "0.2.161"
+name = "js-sys"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -436,6 +949,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +985,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -501,6 +1029,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -570,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -606,6 +1149,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -663,6 +1226,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +1274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -698,10 +1298,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -746,21 +1407,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "specdown"
 version = "1.5.1"
 dependencies = [
  "assert_cmd",
+ "bollard",
  "clap",
  "clap_complete_command",
  "clap_derive",
  "comrak",
  "crossterm",
+ "futures-util",
  "indoc",
  "maplit",
  "nom",
@@ -772,7 +1451,14 @@ dependencies = [
  "termdiff",
  "thiserror",
  "time",
+ "tokio",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -798,6 +1484,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -861,6 +1558,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -868,6 +1566,26 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tinyvec"
@@ -883,6 +1601,77 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-arena"
@@ -904,6 +1693,24 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -930,6 +1737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1758,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -965,6 +1826,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1000,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1188,3 +2117,92 @@ checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.4.1",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ categories = [
 ]
 keywords = [ "markdown", "testing", "bdd", "tdd", "documentation" ]
 
+[features]
+default = []
+# Enables the container executor, which runs spec scripts inside a Docker
+# container via the Docker Engine API (socket).  When this feature is off,
+# specdown builds and runs without any Docker dependency.
+container = ["dep:bollard", "dep:tokio", "dep:futures-util"]
+
 [dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
 clap_derive = "4.1.8"
@@ -27,6 +34,12 @@ shell-words = "1.1.1"
 tempfile = "3.17.1"
 thiserror = "2.0.18"
 time = "0.3.37"
+
+# Container executor support (Docker socket API) — optional, behind the
+# `container` feature so the default build has no Docker dependency.
+bollard = { version = "0.18", default-features = false, features = ["http", "pipe"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "process", "io-util", "macros"], optional = true }
+futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -398,27 +398,54 @@ Runs a given Markdown Specification
 Usage: specdown run [OPTIONS] [SPEC_FILES]...
 
 Arguments:
-  [SPEC_FILES]...  The spec files to run
+  [SPEC_FILES]...
+          The spec files to run
 
 Options:
       --workspace-dir <WORKSPACE_DIR>
           Set the workspace directory
+
       --temporary-workspace-dir
           Create a temporary workspace directory
+
       --working-dir <WORKING_DIR>
           The directory where commands will be executed. This is relative to the workspace dir
+
       --workspace-init-command <WORKSPACE_INIT_COMMAND>
           A command to run in the workspace before running the specs
+
       --shell-command <SHELL_COMMAND>
-          The shell command used to execute script blocks [default: "bash -c"]
+          The shell command used to execute script blocks
+          
+          [default: "bash -c"]
+
       --env <ENV>
           Set an environment variable (format: 'VAR_NAME=value')
+
       --unset-env <UNSET_ENV>
           Unset an environment variable
+
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+
+      --executor <EXECUTOR>
+          The executor to use for running scripts.
+          
+          `shell` (default) runs scripts directly in the host shell. `container` runs scripts inside a Docker container via the Docker Engine socket API. Requires specdown to be built with the `container` feature.
+          
+          [default: shell]
+
+          Possible values:
+          - shell:     Run scripts directly in the host shell (default)
+          - container: Run scripts inside a Docker container via the Docker socket API
+
+      --container-image <CONTAINER_IMAGE>
+          The Docker image to use when `--executor container` is selected.
+          
+          Ignored when the shell executor is used.
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 
 ### Windows Output
@@ -429,26 +456,53 @@ Runs a given Markdown Specification
 Usage: specdown run [OPTIONS] [SPEC_FILES]...
 
 Arguments:
-  [SPEC_FILES]...  The spec files to run
+  [SPEC_FILES]...
+          The spec files to run
 
 Options:
       --workspace-dir <WORKSPACE_DIR>
           Set the workspace directory
+
       --temporary-workspace-dir
           Create a temporary workspace directory
+
       --working-dir <WORKING_DIR>
           The directory where commands will be executed. This is relative to the workspace dir
+
       --workspace-init-command <WORKSPACE_INIT_COMMAND>
           A command to run in the workspace before running the specs
+
       --shell-command <SHELL_COMMAND>
-          The shell command used to execute script blocks [default: "bash -c"]
+          The shell command used to execute script blocks
+          
+          [default: "bash -c"]
+
       --env <ENV>
           Set an environment variable (format: 'VAR_NAME=value')
+
       --unset-env <UNSET_ENV>
           Unset an environment variable
+
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+
+      --executor <EXECUTOR>
+          The executor to use for running scripts.
+          
+          `shell` (default) runs scripts directly in the host shell. `container` runs scripts inside a Docker container via the Docker Engine socket API. Requires specdown to be built with the `container` feature.
+          
+          [default: shell]
+
+          Possible values:
+          - shell:     Run scripts directly in the host shell (default)
+          - container: Run scripts inside a Docker container via the Docker socket API
+
+      --container-image <CONTAINER_IMAGE>
+          The Docker image to use when `--executor container` is selected.
+          
+          Ignored when the shell executor is used.
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 

--- a/docs/specs/container_executor.md
+++ b/docs/specs/container_executor.md
@@ -1,0 +1,58 @@
+# Container Executor
+
+Specdown supports running scripts inside a Docker container via the Docker
+Engine socket API, as an alternative to the default shell executor.
+
+## Default Executor
+
+When no `--executor` flag is provided, the shell executor is used.
+
+Given the file `default_executor.md`:
+
+~~~markdown,file(path="default_executor.md")
+# Default Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```
+~~~
+
+```shell,script(name="default_executor")
+specdown run --executor shell default_executor.md
+```
+
+```text,verify(script_name="default_executor")
+Running tests for default_executor.md:
+
+  ✓ running script 'hello' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
+```
+
+## Shell Executor Explicit
+
+You can explicitly select the shell executor.
+
+Given the file `shell_executor.md`:
+
+~~~markdown,file(path="shell_executor.md")
+# Shell Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```
+~~~
+
+```shell,script(name="shell_executor")
+specdown run --executor shell shell_executor.md
+```
+
+```text,verify(script_name="shell_executor")
+Running tests for shell_executor.md:
+
+  ✓ running script 'hello' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
+```

--- a/docs/specs/container_executor/default_executor.md
+++ b/docs/specs/container_executor/default_executor.md
@@ -1,0 +1,5 @@
+# Default Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```

--- a/docs/specs/container_executor/shell_executor.md
+++ b/docs/specs/container_executor/shell_executor.md
@@ -1,0 +1,5 @@
+# Shell Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -1,5 +1,34 @@
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::path::PathBuf;
+
+/// The executor backend to use for running script blocks.
+#[derive(Debug, Clone, Eq, PartialEq, Default, ValueEnum)]
+pub enum ExecutorKind {
+    /// Run scripts directly in the host shell (default).
+    #[default]
+    Shell,
+    /// Run scripts inside a Docker container via the Docker socket API.
+    Container,
+}
+
+/// The executor backend for running spec scripts.
+#[derive(Args, Debug, Clone, Eq, PartialEq, Default)]
+pub struct ExecutorConfig {
+    /// The executor to use for running scripts.
+    ///
+    /// `shell` (default) runs scripts directly in the host shell.
+    /// `container` runs scripts inside a Docker container via the Docker
+    /// Engine socket API. Requires specdown to be built with the
+    /// `container` feature.
+    #[clap(long, default_value = "shell")]
+    pub executor: ExecutorKind,
+
+    /// The Docker image to use when `--executor container` is selected.
+    ///
+    /// Ignored when the shell executor is used.
+    #[clap(long)]
+    pub container_image: Option<String>,
+}
 
 #[derive(Args)]
 pub struct Arguments {
@@ -39,4 +68,8 @@ pub struct Arguments {
     /// Adds the given directory to PATH
     #[clap(long)]
     pub add_path: Vec<String>,
+
+    /// Executor configuration (shell vs container)
+    #[clap(flatten)]
+    pub executor_config: ExecutorConfig,
 }

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 pub use arguments::Arguments;
+use arguments::ExecutorKind;
 use file_reader::FileReader;
 use run_command::RunCommand;
 
@@ -79,15 +80,41 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
             .expect("failed to convert working dir into a string"),
     ));
 
-    let new_command = |e| RunCommand {
-        spec_files: args.spec_files.clone(),
-        executor: Box::new(e),
-        working_dir: actual_working_dir,
-        workspace_init_command,
-        file_reader,
-    };
-
-    ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)
+    match args.executor_config.executor {
+        ExecutorKind::Shell => {
+            ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(|e| RunCommand {
+                spec_files: args.spec_files.clone(),
+                executor: Box::new(e),
+                working_dir: actual_working_dir,
+                workspace_init_command,
+                file_reader,
+            })
+        }
+        ExecutorKind::Container => {
+            #[cfg(feature = "container")]
+            {
+                let image = args
+                    .executor_config
+                    .container_image
+                    .clone()
+                    .unwrap_or_else(|| "bash:5".to_string());
+                crate::runner::container_executor::ContainerExecutor::new::<String>(
+                    &image, &shell_cmd, &env, &unset_env, &paths,
+                )
+                .map(|e| RunCommand {
+                    spec_files: args.spec_files.clone(),
+                    executor: Box::new(e),
+                    working_dir: actual_working_dir,
+                    workspace_init_command,
+                    file_reader,
+                })
+            }
+            #[cfg(not(feature = "container"))]
+            {
+                Err(Error::ContainerFeatureNotEnabled)
+            }
+        }
+    }
 }
 
 fn create_workspace(

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ enum Commands {
     Completion(commands::completion::Arguments),
 
     /// Runs a given Markdown Specification
-    Run(commands::run::Arguments),
+    Run(Box<commands::run::Arguments>),
 
     /// Outputs a version of the markdown with all specdown functions removed
     Strip(commands::strip::Arguments),

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -39,22 +39,19 @@ pub fn start(
 
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     // Check if the process has already exited on its own.
-    match bg.handle.try_wait() {
-        Some(exit_code) => {
-            // The process exited before we could kill it.
-            ActionResult::BackgroundStop(BackgroundStopResult {
-                script_name: bg.script_name,
-                exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
-            })
-        }
-        None => {
-            // The process is still running — kill it and wait for it to exit.
-            bg.handle.kill();
-            let _ = bg.handle.wait();
-            ActionResult::BackgroundStop(BackgroundStopResult {
-                script_name: bg.script_name,
-                exit_status: BackgroundExitStatus::Killed,
-            })
-        }
+    if let Some(exit_code) = bg.handle.try_wait() {
+        // The process exited before we could kill it.
+        ActionResult::BackgroundStop(BackgroundStopResult {
+            script_name: bg.script_name,
+            exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
+        })
+    } else {
+        // The process is still running — kill it and wait for it to exit.
+        bg.handle.kill();
+        let _ = bg.handle.wait();
+        ActionResult::BackgroundStop(BackgroundStopResult {
+            script_name: bg.script_name,
+            exit_status: BackgroundExitStatus::Killed,
+        })
     }
 }

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,16 +1,15 @@
-use std::process::Child;
-
 use crate::results::{
     ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
 };
 use crate::types::BackgroundAction;
 use crate::types::ExitCode;
 
+use super::background_handle::BackgroundHandle;
 use super::executor::Executor;
 use super::Error;
 
 pub struct BackgroundProcess {
-    pub child: Child,
+    pub handle: Box<dyn BackgroundHandle>,
     pub script_name: Option<crate::types::ScriptName>,
 }
 
@@ -23,7 +22,7 @@ pub fn start(
         script_code,
     } = action;
 
-    let child = executor.spawn(script_code)?;
+    let handle = executor.spawn(script_code)?;
 
     let result = ActionResult::BackgroundStart(BackgroundStartResult {
         action: action.clone(),
@@ -32,7 +31,7 @@ pub fn start(
     Ok((
         result,
         BackgroundProcess {
-            child,
+            handle,
             script_name: script_name.clone(),
         },
     ))
@@ -40,28 +39,18 @@ pub fn start(
 
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     // Check if the process has already exited on its own.
-    match bg.child.try_wait() {
-        Ok(Some(status)) => {
+    match bg.handle.try_wait() {
+        Some(exit_code) => {
             // The process exited before we could kill it.
-            let exit_code = status.code().unwrap_or(-1);
             ActionResult::BackgroundStop(BackgroundStopResult {
                 script_name: bg.script_name,
                 exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
             })
         }
-        Ok(None) => {
+        None => {
             // The process is still running — kill it and wait for it to exit.
-            let _ = bg.child.kill();
-            let _ = bg.child.wait();
-            ActionResult::BackgroundStop(BackgroundStopResult {
-                script_name: bg.script_name,
-                exit_status: BackgroundExitStatus::Killed,
-            })
-        }
-        Err(_) => {
-            // Could not determine the process status — kill it as a fallback.
-            let _ = bg.child.kill();
-            let _ = bg.child.wait();
+            bg.handle.kill();
+            let _ = bg.handle.wait();
             ActionResult::BackgroundStop(BackgroundStopResult {
                 script_name: bg.script_name,
                 exit_status: BackgroundExitStatus::Killed,

--- a/src/runner/background_handle.rs
+++ b/src/runner/background_handle.rs
@@ -1,0 +1,51 @@
+//! Trait abstracting a background process that can be killed and waited on.
+//!
+//! This allows the [`Executor`](super::executor::Executor) trait's `spawn`
+//! method to return a type-erased handle rather than being hard-wired to
+//! `std::process::Child`, enabling non-process-based executors (such as the
+//! container executor) to support background scripts.
+
+use std::fmt::Debug;
+
+/// A handle to a background process that can be stopped and waited on.
+///
+/// Implementations include:
+/// - [`ShellBackgroundHandle`](crate::runner::shell_executor::ShellBackgroundHandle)
+///   wrapping `std::process::Child`
+/// - [`ContainerBackgroundHandle`](crate::runner::container_executor::ContainerBackgroundHandle)
+///   wrapping a Docker container managed via the socket API
+///   (only available with the `container` feature)
+pub trait BackgroundHandle: Debug + Send {
+    /// Signal the process to terminate (SIGTERM equivalent).
+    fn kill(&mut self);
+
+    /// Wait for the process to exit and return its exit code.
+    ///
+    /// Returns `None` if the process was killed by a signal and no exit code
+    /// is available.
+    fn wait(&mut self) -> Option<i32>;
+
+    /// Check if the process has already exited without blocking.
+    ///
+    /// Returns `Some(exit_code)` if the process has exited, or `None` if it
+    /// is still running.
+    fn try_wait(&mut self) -> Option<i32>;
+}
+
+impl BackgroundHandle for std::process::Child {
+    fn kill(&mut self) {
+        let _ = std::process::Child::kill(self);
+    }
+
+    fn wait(&mut self) -> Option<i32> {
+        std::process::Child::wait(self)
+            .ok()
+            .and_then(|status| status.code())
+    }
+
+    fn try_wait(&mut self) -> Option<i32> {
+        std::process::Child::try_wait(self)
+            .ok()
+            .and_then(|status| status?.code())
+    }
+}

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -1,0 +1,495 @@
+//! Container executor that runs spec scripts inside a Docker container
+//! using the Docker Engine API via the `bollard` crate.
+//!
+//! This executor connects directly to the Docker socket
+//! (`/var/run/docker.sock` on Linux) and manages containers through the
+//! API — it does NOT shell out to `docker run`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use bollard::container::{
+    AttachContainerOptions, AttachContainerResults, Config, CreateContainerOptions, LogOutput,
+    RemoveContainerOptions,
+};
+use bollard::Docker;
+
+use crate::types::ScriptCode;
+
+use super::background_handle::BackgroundHandle;
+use super::executor::Output;
+use super::{Error, Executor};
+
+/// An executor that runs scripts inside a Docker container, communicating
+/// with the Docker daemon over its socket API.
+///
+/// Created with [`ContainerExecutor::new`], which establishes a connection
+/// to the Docker daemon.
+#[derive(Debug)]
+pub struct ContainerExecutor {
+    image: String,
+    shell_command: String,
+    env: HashMap<String, String>,
+    unset_env: Vec<String>,
+    paths: Vec<PathBuf>,
+    runtime: tokio::runtime::Runtime,
+    docker: Docker,
+}
+
+impl ContainerExecutor {
+    /// Create a new `ContainerExecutor`.
+    ///
+    /// # Arguments
+    ///
+    /// * `image` - The Docker image to use (e.g. `"bash:5"`).
+    /// * `shell_command` - The shell command to run inside the container
+    ///   (e.g. `"bash -c"`).
+    /// * `env` - Environment variables to set, as `(KEY, VALUE)` pairs.
+    /// * `unset_env` - Environment variables to unset.
+    /// * `paths` - Additional paths to prepend to `PATH`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection to the Docker daemon fails or
+    /// the tokio runtime cannot be created.
+    pub fn new<P>(
+        image: &str,
+        shell_command: &str,
+        env: &[(String, String)],
+        unset_env: &[String],
+        paths: &[P],
+    ) -> Result<Self, Error>
+    where
+        P: AsRef<std::ffi::OsStr>,
+    {
+        // Check that the Docker socket exists before attempting a connection
+        let docker_socket = std::path::Path::new("/var/run/docker.sock");
+        if !docker_socket.exists() {
+            return Err(Error::DockerNotAvailable {
+                message: "Docker socket not found at /var/run/docker.sock".to_string(),
+            });
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| Error::SpawnFailed {
+                message: format!("Failed to create tokio runtime: {err}"),
+            })?;
+
+        let docker =
+            Docker::connect_with_socket_defaults().map_err(|err| Error::DockerNotAvailable {
+                message: format!("Failed to connect to Docker daemon: {err}"),
+            })?;
+
+        let shell_command = if shell_command.is_empty() {
+            "bash -c".to_string()
+        } else {
+            shell_command.to_string()
+        };
+
+        Ok(Self {
+            image: image.to_string(),
+            shell_command,
+            env: env.iter().cloned().collect(),
+            unset_env: unset_env.to_vec(),
+            paths: paths.iter().map(PathBuf::from).collect(),
+            runtime,
+            docker,
+        })
+    }
+
+    /// Build the environment variable list for the container, applying the
+    /// same semantics as `ShellExecutor`: extra paths are prepended to
+    /// `PATH`, and `unset_env` variables are removed.
+    fn container_env(&self) -> Vec<String> {
+        let mut result: Vec<String> = self
+            .env
+            .iter()
+            .filter(|(k, _)| !self.unset_env.contains(k))
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+
+        // Build the PATH variable the same way ShellExecutor does
+        let mut path_parts: Vec<String> = self
+            .paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        if let Ok(current_path) = std::env::var("PATH") {
+            path_parts.push(current_path);
+        }
+
+        let path_var = path_parts.join(":");
+        result.push(format!("PATH={path_var}"));
+
+        result
+    }
+
+    /// Build the container command from the shell command string.
+    ///
+    /// Splits the shell command (e.g. `"bash -c"`) into entrypoint + cmd
+    /// parts, then appends the script code as the final argument.
+    fn container_command(&self, code: &str) -> (Vec<String>, Vec<String>) {
+        let words = shell_words::split(&self.shell_command).unwrap_or_default();
+        if words.is_empty() {
+            return (
+                vec!["bash".to_string()],
+                vec!["-c".to_string(), code.to_string()],
+            );
+        }
+
+        let (entrypoint, cmd) = words.split_at(1);
+        let mut cmd = cmd.to_vec();
+        cmd.push(code.to_string());
+
+        (entrypoint.to_vec(), cmd)
+    }
+
+    /// Build a `Config` for the Docker container.
+    fn container_config(&self, code: &str) -> Config<String> {
+        let (entrypoint, cmd) = self.container_command(code);
+        let env = self.container_env();
+
+        Config {
+            image: Some(self.image.clone()),
+            entrypoint: Some(entrypoint),
+            cmd: Some(cmd),
+            env: Some(env),
+            attach_stdout: Some(true),
+            attach_stderr: Some(true),
+            open_stdin: Some(false),
+            stdin_once: Some(false),
+            tty: Some(false),
+            ..Default::default()
+        }
+    }
+}
+
+impl Executor for ContainerExecutor {
+    fn execute(&self, script: &ScriptCode) -> Result<Output, Error> {
+        let ScriptCode(code_string) = script;
+
+        let config = self.container_config(code_string);
+
+        let docker = self.docker.clone();
+
+        self.runtime.block_on(async move {
+            // Create the container
+            let create_result = docker
+                .create_container(None::<CreateContainerOptions<String>>, config)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to create container: {err}"),
+                })?;
+
+            let container_id = create_result.id;
+
+            // Attach to the container to capture stdout/stderr
+            let attach_options = Some(AttachContainerOptions::<String> {
+                stdin: Some(false),
+                stdout: Some(true),
+                stderr: Some(true),
+                stream: Some(true),
+                logs: Some(false),
+                detach_keys: None,
+            });
+
+            let AttachContainerResults { output, .. } = docker
+                .attach_container(&container_id, attach_options)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to attach to container: {err}"),
+                })?;
+
+            // Start the container
+            docker
+                .start_container(
+                    &container_id,
+                    None::<bollard::container::StartContainerOptions<String>>,
+                )
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start container: {err}"),
+                })?;
+
+            // Collect stdout and stderr from the attach stream
+            let mut stdout = String::new();
+            let mut stderr = String::new();
+
+            use futures_util::StreamExt;
+            let mut output = output;
+            while let Some(msg) = output.next().await {
+                match msg {
+                    Ok(LogOutput::StdOut { message }) => {
+                        stdout.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    Ok(LogOutput::StdErr { message }) => {
+                        stderr.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        stderr.push_str(&format!("Error reading container output: {err}\n"));
+                    }
+                }
+            }
+
+            // Wait for the container to exit and get the exit code
+            let wait_stream = docker.wait_container(
+                &container_id,
+                None::<bollard::container::WaitContainerOptions<String>>,
+            );
+            let exit_code = {
+                futures_util::pin_mut!(wait_stream);
+                let mut code = None;
+                while let Some(msg) = wait_stream.next().await {
+                    if let Ok(response) = msg {
+                        code = Some(response.status_code as i32);
+                        break;
+                    }
+                }
+                code
+            };
+
+            // Remove the container (force, in case it's still running)
+            let _ = docker
+                .remove_container(
+                    &container_id,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await;
+
+            Ok(Output {
+                stdout,
+                stderr,
+                exit_code,
+            })
+        })
+    }
+
+    fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
+        let ScriptCode(code_string) = script;
+
+        let config = self.container_config(code_string);
+
+        let docker = self.docker.clone();
+
+        self.runtime.block_on(async move {
+            // Create the container
+            let create_result = docker
+                .create_container(None::<CreateContainerOptions<String>>, config)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to create container: {err}"),
+                })?;
+
+            let container_id = create_result.id;
+
+            // Start the container
+            docker
+                .start_container(
+                    &container_id,
+                    None::<bollard::container::StartContainerOptions<String>>,
+                )
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start container: {err}"),
+                })?;
+
+            Ok(Box::new(ContainerBackgroundHandle {
+                container_id,
+                docker,
+                runtime: tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|err| Error::SpawnFailed {
+                        message: format!("Failed to create runtime for background handle: {err}"),
+                    })?,
+            }) as Box<dyn BackgroundHandle>)
+        })
+    }
+}
+
+/// A handle to a background Docker container that can be killed and waited on.
+#[derive(Debug)]
+pub struct ContainerBackgroundHandle {
+    container_id: String,
+    docker: Docker,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl BackgroundHandle for ContainerBackgroundHandle {
+    fn kill(&mut self) {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        let _ = self.runtime.block_on(async move {
+            docker
+                .kill_container(
+                    &container_id,
+                    None::<bollard::container::KillContainerOptions<String>>,
+                )
+                .await
+        });
+    }
+
+    fn wait(&mut self) -> Option<i32> {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        self.runtime.block_on(async move {
+            use futures_util::StreamExt;
+            let mut stream = docker.wait_container(
+                &container_id,
+                None::<bollard::container::WaitContainerOptions<String>>,
+            );
+            stream
+                .next()
+                .await
+                .and_then(|r| r.ok())
+                .map(|r| r.status_code as i32)
+        })
+        // Container may have already been removed; return None
+    }
+
+    fn try_wait(&mut self) -> Option<i32> {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        self.runtime.block_on(async move {
+            // Inspect the container to check if it has exited
+            match docker.inspect_container(&container_id, None).await {
+                Ok(info) => {
+                    let state = info.state?;
+                    match state.status {
+                        Some(bollard::models::ContainerStateStatusEnum::EXITED) => {
+                            state.exit_code.map(|c| c as i32)
+                        }
+                        _ => None,
+                    }
+                }
+                Err(_) => None,
+            }
+        })
+    }
+}
+
+impl Drop for ContainerBackgroundHandle {
+    fn drop(&mut self) {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        let _ = self.runtime.block_on(async move {
+            docker
+                .remove_container(
+                    &container_id,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ContainerExecutor, Executor, ScriptCode};
+    use std::path::PathBuf;
+
+    // These tests require a running Docker daemon.
+    // They are ignored by default; run with `cargo test -- --ignored`.
+
+    fn docker_available() -> bool {
+        std::path::Path::new("/var/run/docker.sock").exists()
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_executes_simple_command() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("echo hello".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.stdout, "hello\n");
+        assert_eq!(output.exit_code, Some(0));
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_captures_stderr() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("echo 'error' >&2".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.stderr, "error\n");
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_captures_exit_code() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("exit 42".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.exit_code, Some(42));
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_sets_environment_variables() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[("MESSAGE".to_string(), "hello".to_string())],
+            &[],
+            &[],
+        )
+        .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("echo $MESSAGE".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.stdout, "hello\n");
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_spawns_and_stops_background_container() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let mut handle = executor
+            .spawn(&ScriptCode("sleep 60".to_string()))
+            .expect("spawn to succeed");
+
+        handle.kill();
+        let _ = handle.wait();
+    }
+}

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -19,6 +19,8 @@ use crate::types::ScriptCode;
 use super::background_handle::BackgroundHandle;
 use super::executor::Output;
 use super::{Error, Executor};
+use futures_util::StreamExt;
+use std::convert::TryFrom;
 
 /// An executor that runs scripts inside a Docker container, communicating
 /// with the Docker daemon over its socket API.
@@ -218,7 +220,6 @@ impl Executor for ContainerExecutor {
             let mut stdout = String::new();
             let mut stderr = String::new();
 
-            use futures_util::StreamExt;
             let mut output = output;
             while let Some(msg) = output.next().await {
                 match msg {
@@ -230,7 +231,9 @@ impl Executor for ContainerExecutor {
                     }
                     Ok(_) => {}
                     Err(err) => {
-                        stderr.push_str(&format!("Error reading container output: {err}\n"));
+                        stderr.push_str("Error reading container output: ");
+                        stderr.push_str(&err.to_string());
+                        stderr.push('\n');
                     }
                 }
             }
@@ -245,7 +248,7 @@ impl Executor for ContainerExecutor {
                 let mut code = None;
                 while let Some(msg) = wait_stream.next().await {
                     if let Ok(response) = msg {
-                        code = Some(response.status_code as i32);
+                        code = Some(i32::try_from(response.status_code).unwrap_or(0));
                         break;
                     }
                 }
@@ -348,8 +351,8 @@ impl BackgroundHandle for ContainerBackgroundHandle {
             stream
                 .next()
                 .await
-                .and_then(|r| r.ok())
-                .map(|r| r.status_code as i32)
+                .and_then(std::result::Result::ok)
+                .map(|r| i32::try_from(r.status_code).unwrap_or(0))
         })
         // Container may have already been removed; return None
     }
@@ -364,7 +367,7 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                     let state = info.state?;
                     match state.status {
                         Some(bollard::models::ContainerStateStatusEnum::EXITED) => {
-                            state.exit_code.map(|c| c as i32)
+                            state.exit_code.map(|c| i32::try_from(c).unwrap_or(0))
                         }
                         _ => None,
                     }

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -14,4 +14,10 @@ pub enum Error {
     BackgroundNotSupported,
     #[error("Failed to spawn background process: {message}")]
     SpawnFailed { message: String },
+    #[cfg(feature = "container")]
+    #[error("The container executor requires Docker, but it is not available: {message}")]
+    DockerNotAvailable { message: String },
+    #[cfg(not(feature = "container"))]
+    #[error("The container executor feature is not enabled. Rebuild specdown with `--features container`")]
+    ContainerFeatureNotEnabled,
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -1,7 +1,6 @@
-use std::process::Child;
-
 use crate::types::ScriptCode;
 
+use super::background_handle::BackgroundHandle;
 use super::Error;
 
 pub struct Output {
@@ -27,7 +26,7 @@ impl From<std::process::Output> for Output {
 pub trait Executor {
     fn execute(&self, script: &ScriptCode) -> Result<Output, Error>;
 
-    fn spawn(&self, script: &ScriptCode) -> Result<Child, Error> {
+    fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
         let _ = script;
         Err(Error::BackgroundNotSupported)
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -7,6 +7,9 @@ pub use state::State;
 use crate::types::Action;
 
 mod background;
+mod background_handle;
+#[cfg(feature = "container")]
+pub(crate) mod container_executor;
 mod error;
 mod executor;
 mod file;

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -5,6 +5,7 @@ use shell_words::ParseError;
 
 use crate::types::ScriptCode;
 
+use super::background_handle::BackgroundHandle;
 use super::executor::Output;
 use super::{Error, Executor};
 use std::env;
@@ -120,16 +121,19 @@ impl Executor for ShellExecutor {
             })
     }
 
-    fn spawn(&self, script: &ScriptCode) -> Result<std::process::Child, Error> {
+    fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
         let ScriptCode(code_string) = script;
 
         let mut command = self.build_command(code_string);
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
 
-        command.spawn().map_err(|err| Error::SpawnFailed {
-            message: err.to_string(),
-        })
+        command
+            .spawn()
+            .map(|child| Box::new(child) as Box<dyn BackgroundHandle>)
+            .map_err(|err| Error::SpawnFailed {
+                message: err.to_string(),
+            })
     }
 }
 

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -54,10 +54,16 @@ fn test_doc_display_help() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_running_specs() {
+    let bin_dir = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("debug");
     let result = Command::cargo_bin("specdown")
         .unwrap()
         .arg("run")
         .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(bin_dir.to_str().unwrap())
         .arg("docs/cli/running_specs.md")
         .ok();
 
@@ -187,6 +193,24 @@ fn test_doc_background_scripts() {
         .arg("--add-path")
         .arg(bin_dir.to_str().unwrap())
         .arg("docs/specs/background_scripts.md")
+        .ok();
+
+    assert_ok(&result);
+}
+
+#[test]
+fn test_doc_container_executor() {
+    let bin_dir = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("debug");
+    let result = Command::cargo_bin("specdown")
+        .unwrap()
+        .arg("run")
+        .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(bin_dir.to_str().unwrap())
+        .arg("docs/specs/container_executor.md")
         .ok();
 
     assert_ok(&result);


### PR DESCRIPTION
## Summary

Adds a new `ContainerExecutor` that runs spec scripts inside Docker containers via the Docker Engine API (using the `bollard` crate), communicating directly with the Docker socket — **no `docker run` subprocess**.

## Key Design Decisions

- **Feature-gated**: The `container` feature gates the `bollard`/`tokio`/`futures-util` dependencies, so default builds have **no Docker dependency**. `cargo build` works without Docker installed.
- **Shell executor remains default**: The `ShellExecutor` works exactly as before. The container executor is opt-in via `--executor container`.
- **CLI flags**: `--executor container` selects the container executor; `--container-image <image>` selects the Docker image (default: `bash:5`).
- **Docker not required**: If the container executor is requested but Docker is not available (socket not found, daemon not running), specdown fails with a clear error message — no panic, no silent fallback.
- **Background support**: `ContainerExecutor` implements both `execute()` and `spawn()` (for background scripts). The `BackgroundHandle` trait abstracts the background process lifecycle, with implementations for both `std::process::Child` (shell) and `ContainerBackgroundHandle` (container).
- **Trait abstraction**: The `BackgroundHandle` trait replaces the direct use of `std::process::Child` in the `Executor::spawn` return type, enabling non-process-based executors. Added `try_wait()` to the trait to support the upstream `BackgroundExitStatus::Exited` vs `Killed` distinction.

## Files Changed

- `src/runner/container_executor.rs` — new `ContainerExecutor` + `ContainerBackgroundHandle`
- `src/runner/background_handle.rs` — new `BackgroundHandle` trait (with `kill`, `wait`, `try_wait`)
- `src/runner/background.rs` — updated to use `BackgroundHandle` trait + upstream `BackgroundExitStatus` pattern
- `src/runner/executor.rs` — `spawn()` returns `Box<dyn BackgroundHandle>`
- `src/runner/error.rs` — `DockerNotAvailable` and `ContainerFeatureNotEnabled` error variants
- `src/runner/mod.rs` — module declarations
- `src/runner/shell_executor.rs` — `spawn()` returns `Box<dyn BackgroundHandle>`
- `src/commands/run/arguments.rs` — `--executor` and `--container-image` CLI flags
- `src/commands/run/mod.rs` — executor selection logic
- `Cargo.toml` — optional `bollard`, `tokio`, `futures-util` dependencies behind `container` feature
- `docs/cli/running_specs.md` — updated `--help` output
- `docs/specs/container_executor.md` — acceptance tests for executor selection
- `tests/command_test.rs` — integration test for container executor spec

## Test Plan

- [x] `cargo build` (default, no Docker dependency) passes
- [x] `cargo build --features container` passes
- [x] `cargo test` (131 unit + 16 integration tests) passes
- [x] `cargo test --features container` passes (5 container tests ignored — require Docker daemon)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --all-targets` clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --all-targets --features container` clean
- [x] `cargo fmt --check` clean