### PR TITLE
feat(run): add --jobs/-j CLI flag to specdown run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,7 +419,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -434,6 +440,16 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -764,6 +780,7 @@ dependencies = [
  "indoc",
  "maplit",
  "nom",
+ "num_cpus",
  "quickcheck",
  "quickcheck_macros",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,10 @@ shell-words = "1.1.1"
 tempfile = "3.17.1"
 thiserror = "2.0.18"
 time = "0.3.37"
-
+num_cpus = "1.16"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"
 maplit = "1.0.2"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-tempfile = "3.17.1"

--- a/docs/specs/jobs_flag.md
+++ b/docs/specs/jobs_flag.md
@@ -1,0 +1,69 @@
+# Jobs Flag
+
+The `--jobs` / `-j` flag controls how many specs can run in parallel.
+
+## Default value
+
+When `--jobs` is not specified, the default is `1` (sequential execution).
+
+```shell,script(name="jobs_default")
+specdown run --help 2>&1 | grep '\-\-jobs'
+```
+
+```text,verify(script_name="jobs_default")
+  -j, --jobs <JOBS>
+```
+
+## Test spec file
+
+We need a simple spec file to run the jobs flag against:
+
+~~~markdown,file(path="simple_spec.md")
+# Simple Spec
+
+```shell,script(name="simple_test",expected_exit_code=0)
+echo hello
+```
+
+```text,verify(script_name="simple_test")
+hello
+```
+~~~
+
+## Explicit job count
+
+Specifying `--jobs 4` should be accepted:
+
+```shell,script(name="jobs_explicit", expected_exit_code=0)
+specdown run --jobs 4 --temporary-workspace-dir simple_spec.md
+```
+
+## Short flag
+
+The `-j` short flag should also work:
+
+```shell,script(name="jobs_short", expected_exit_code=0)
+specdown run -j 2 --temporary-workspace-dir simple_spec.md
+```
+
+## Zero means parallel
+
+Specifying `-j 0` means "use all CPUs" and should be accepted:
+
+```shell,script(name="jobs_zero", expected_exit_code=0)
+specdown run -j 0 --temporary-workspace-dir simple_spec.md
+```
+
+## Negative values are rejected
+
+Negative values should produce an error:
+
+```shell,script(name="jobs_negative", expected_exit_code=2)
+specdown run --jobs -1 --temporary-workspace-dir simple_spec.md
+```
+
+```text,verify(script_name="jobs_negative", stream=stderr)
+error: invalid value '-1' for '--jobs <JOBS>': -1 is not in 0..=4294967295
+
+For more information, try '--help'.
+```

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -39,4 +39,11 @@ pub struct Arguments {
     /// Adds the given directory to PATH
     #[clap(long)]
     pub add_path: Vec<String>,
+
+    /// Number of parallel jobs to run.
+    ///
+    /// Set to 0 to run all specs in parallel (uses the number of CPUs).
+    /// Defaults to 1 (sequential execution) for backward compatibility.
+    #[clap(short = 'j', long = "jobs", default_value_t = 1, allow_hyphen_values = true, value_parser = clap::value_parser!(u32).range(0..))]
+    pub jobs: u32,
 }

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -39,6 +39,13 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
     let shell_cmd = args.shell_command.clone();
     let mut env = parse_environment_variables(&args.env);
 
+    // Resolve jobs: 0 means "run all in parallel" — map to CPU count.
+    let jobs = if args.jobs == 0 {
+        num_cpus::get()
+    } else {
+        args.jobs as usize
+    };
+
     let unset_env = args.unset_env.clone();
     let paths = args.add_path.clone();
     let current_dir = std::env::current_dir().expect("Failed to get current workspace directory");
@@ -85,6 +92,7 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
         working_dir: actual_working_dir,
         workspace_init_command,
         file_reader,
+        jobs,
     };
 
     ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -12,6 +12,13 @@ pub struct RunCommand {
     pub working_dir: PathBuf,
     pub workspace_init_command: Option<String>,
     pub file_reader: FileReader,
+    /// The number of parallel jobs to use when running specs.
+    ///
+    /// A value of 0 has already been resolved to the CPU count by the CLI layer.
+    /// The parallel execution logic is not implemented yet; the value is plumbed
+    /// through so a follow-up can use it.
+    #[allow(dead_code)]
+    pub jobs: usize,
 }
 
 impl RunCommand {


### PR DESCRIPTION
## Summary

Adds a `--jobs <N>` / `-j <N>` flag to the `specdown run` command. This is plumbing only — no parallel execution logic is implemented yet.

## Behaviour

- `specdown run` (no flag) → defaults to 1 (sequential, backward-compatible)
- `specdown run --jobs 4` → accepted, value passed to `RunCommand`
- `specdown run -j 0` → accepted, resolves 0 to `num_cpus::get()` at the CLI layer
- `specdown run --jobs -1` → rejected with a clear validation error (exit code 2)

## Changes

- `src/commands/run/arguments.rs` — new clap field: `jobs: u32` with `-j`/`--jobs`, `default_value_t = 1`, `allow_hyphen_values = true`, `value_parser!(u32).range(0..)` (rejects negatives)
- `src/commands/run/mod.rs` — resolves `0` → `num_cpus::get()`, passes `jobs: usize` into `RunCommand`
- `src/commands/run/run_command.rs` — new `jobs: usize` field on `RunCommand` (marked `#[allow(dead_code)]` since parallel execution is intentionally not implemented in this PR)
- `Cargo.toml` / `Cargo.lock` — added `num_cpus` dependency
- `docs/specs/jobs_flag.md` — specdown acceptance tests covering all four acceptance criteria

## Verification

- `cargo build --release` — clean, no warnings
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic -D clippy::cargo -A clippy::multiple-crate-versions` — clean
- `cargo test --bin specdown` — 167 passed, 0 failed
- specdown acceptance tests on `docs/specs/jobs_flag.md` — 8/8 pass