### PR TITLE
feat(run): implement parallel spec execution with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +641,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +828,7 @@ dependencies = [
  "num_cpus",
  "quickcheck",
  "quickcheck_macros",
+ "rayon",
  "shell-words",
  "strip-ansi-escapes",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,7 +419,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -434,6 +440,16 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -764,6 +780,7 @@ dependencies = [
  "indoc",
  "maplit",
  "nom",
+ "num_cpus",
  "quickcheck",
  "quickcheck_macros",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,10 @@ shell-words = "1.1.1"
 tempfile = "3.17.1"
 thiserror = "2.0.18"
 time = "0.3.37"
-
+num_cpus = "1.16"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"
 maplit = "1.0.2"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-tempfile = "3.17.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = "3.17.1"
 thiserror = "2.0.18"
 time = "0.3.37"
 num_cpus = "1.16"
+rayon = "1.10"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -417,6 +417,8 @@ Options:
           Unset an environment variable
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+  -j, --jobs <JOBS>
+          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
   -h, --help
           Print help
 ```
@@ -448,6 +450,8 @@ Options:
           Unset an environment variable
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+  -j, --jobs <JOBS>
+          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
   -h, --help
           Print help
 ```

--- a/docs/specs/jobs_flag.md
+++ b/docs/specs/jobs_flag.md
@@ -67,3 +67,53 @@ error: invalid value '-1' for '--jobs <JOBS>': -1 is not in 0..=4294967295
 
 For more information, try '--help'.
 ```
+
+## Parallel execution with multiple spec files
+
+When `--jobs > 1`, multiple spec files should run in parallel.
+We create two spec files and run them together with `-j 2`:
+
+~~~markdown,file(path="parallel_spec_a.md")
+# Spec A
+
+```shell,script(name="spec_a_test", expected_exit_code=0)
+echo "from spec a"
+```
+~~~
+
+~~~markdown,file(path="parallel_spec_b.md")
+# Spec B
+
+```shell,script(name="spec_b_test", expected_exit_code=0)
+echo "from spec b"
+```
+~~~
+
+```shell,script(name="parallel_multiple", expected_exit_code=0)
+specdown run -j 2 --temporary-workspace-dir parallel_spec_a.md parallel_spec_b.md
+```
+
+## Parallel execution preserves failure reporting
+
+When running multiple specs in parallel and one fails, the exit code
+should be non-zero:
+
+~~~markdown,file(path="passing_spec.md")
+# Passing Spec
+
+```shell,script(name="passing_test", expected_exit_code=0)
+echo ok
+```
+~~~
+
+~~~markdown,file(path="failing_spec.md")
+# Failing Spec
+
+```shell,script(name="failing_test", expected_exit_code=0)
+exit 1
+```
+~~~
+
+```shell,script(name="parallel_failure", expected_exit_code=1)
+specdown run -j 2 --temporary-workspace-dir passing_spec.md failing_spec.md
+```

--- a/docs/specs/jobs_flag.md
+++ b/docs/specs/jobs_flag.md
@@ -1,0 +1,69 @@
+# Jobs Flag
+
+The `--jobs` / `-j` flag controls how many specs can run in parallel.
+
+## Default value
+
+When `--jobs` is not specified, the default is `1` (sequential execution).
+
+```shell,script(name="jobs_default")
+specdown run --help 2>&1 | grep '\-\-jobs'
+```
+
+```text,verify(script_name="jobs_default")
+  -j, --jobs <JOBS>
+```
+
+## Test spec file
+
+We need a simple spec file to run the jobs flag against:
+
+~~~markdown,file(path="simple_spec.md")
+# Simple Spec
+
+```shell,script(name="simple_test",expected_exit_code=0)
+echo hello
+```
+
+```text,verify(script_name="simple_test")
+hello
+```
+~~~
+
+## Explicit job count
+
+Specifying `--jobs 4` should be accepted:
+
+```shell,script(name="jobs_explicit", expected_exit_code=0)
+specdown run --jobs 4 --temporary-workspace-dir simple_spec.md
+```
+
+## Short flag
+
+The `-j` short flag should also work:
+
+```shell,script(name="jobs_short", expected_exit_code=0)
+specdown run -j 2 --temporary-workspace-dir simple_spec.md
+```
+
+## Zero means parallel
+
+Specifying `-j 0` means "use all CPUs" and should be accepted:
+
+```shell,script(name="jobs_zero", expected_exit_code=0)
+specdown run -j 0 --temporary-workspace-dir simple_spec.md
+```
+
+## Negative values are rejected
+
+Negative values should produce an error:
+
+```shell,script(name="jobs_negative", expected_exit_code=2)
+specdown run --jobs -1 --temporary-workspace-dir simple_spec.md
+```
+
+```text,verify(script_name="jobs_negative", stream=stderr)
+error: invalid value '-1' for '--jobs <JOBS>': -1 is not in 0..=4294967295
+
+For more information, try '--help'.
+```

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -40,10 +40,7 @@ pub struct Arguments {
     #[clap(long)]
     pub add_path: Vec<String>,
 
-    /// Number of parallel jobs to run.
-    ///
-    /// Set to 0 to run all specs in parallel (uses the number of CPUs).
-    /// Defaults to 1 (sequential execution) for backward compatibility.
+    /// Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility)
     #[clap(short = 'j', long = "jobs", default_value_t = 1, allow_hyphen_values = true, value_parser = clap::value_parser!(u32).range(0..))]
     pub jobs: u32,
 }

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -39,4 +39,11 @@ pub struct Arguments {
     /// Adds the given directory to PATH
     #[clap(long)]
     pub add_path: Vec<String>,
+
+    /// Number of parallel jobs to run.
+    ///
+    /// Set to 0 to run all specs in parallel (uses the number of CPUs).
+    /// Defaults to 1 (sequential execution) for backward compatibility.
+    #[clap(short = 'j', long = "jobs", default_value_t = 1, allow_hyphen_values = true, value_parser = clap::value_parser!(u32).range(0..))]
+    pub jobs: u32,
 }

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -39,6 +39,13 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
     let shell_cmd = args.shell_command.clone();
     let mut env = parse_environment_variables(&args.env);
 
+    // Resolve jobs: 0 means "run all in parallel" — map to CPU count.
+    let jobs = if args.jobs == 0 {
+        num_cpus::get()
+    } else {
+        args.jobs as usize
+    };
+
     let unset_env = args.unset_env.clone();
     let paths = args.add_path.clone();
     let current_dir = std::env::current_dir().expect("Failed to get current workspace directory");
@@ -85,6 +92,7 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
         working_dir: actual_working_dir,
         workspace_init_command,
         file_reader,
+        jobs,
     };
 
     ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -95,6 +95,7 @@ impl RunCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::run::exit_code;
     use crate::runner::Output;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::tempdir;
@@ -261,9 +262,6 @@ mod tests {
         );
         let events = with_saved_cwd(|| cmd.execute());
 
-        // The failing executor causes ErrorOccurred events, which the exit_code
-        // module treats as errors (returns ErrorOccurred exit code).
-        use crate::commands::run::exit_code;
         let exit_code = exit_code::from_events(&events);
         assert_ne!(
             exit_code as i32, 0,

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -12,6 +12,13 @@ pub struct RunCommand {
     pub working_dir: PathBuf,
     pub workspace_init_command: Option<String>,
     pub file_reader: FileReader,
+    /// The number of parallel jobs to use when running specs.
+    ///
+    /// A value of 0 has already been resolved to the CPU count by the CLI layer.
+    /// The parallel execution logic is not implemented yet; the value is plumbed
+    /// through so a follow-up can use it.
+    #[allow(dead_code)]
+    pub jobs: usize,
 }
 
 impl RunCommand {

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -98,7 +98,13 @@ mod tests {
     use crate::commands::run::exit_code;
     use crate::runner::Output;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    /// A mutex to serialize tests that change the process-wide CWD
+    /// (`RunCommand::execute()` calls `std::env::set_current_dir`).
+    /// Without this, parallel test execution causes data races on the CWD.
+    static CWD_MUTEX: Mutex<()> = Mutex::new(());
 
     /// A mock executor that always succeeds.
     struct CountingExecutor {
@@ -162,9 +168,10 @@ mod tests {
         }
     }
 
-    /// Helper to run a closure with the CWD saved and restored,
-    /// since `RunCommand::execute()` calls `std::env::set_current_dir`.
+    /// Run a closure while holding the CWD mutex, saving and restoring the
+    /// process-wide working directory around it.
     fn with_saved_cwd<F: FnOnce() -> Vec<RunEvent>>(f: F) -> Vec<RunEvent> {
+        let _guard = CWD_MUTEX.lock().expect("CWD mutex poisoned");
         let original_dir = std::env::current_dir().expect("Failed to get current directory");
         let events = f();
         std::env::set_current_dir(&original_dir).expect("Failed to restore current directory");

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
+
 use crate::parsers;
 use crate::runner::{Error, Executor, RunEvent, Runner, State};
 use crate::types::ScriptCode;
@@ -15,9 +17,7 @@ pub struct RunCommand {
     /// The number of parallel jobs to use when running specs.
     ///
     /// A value of 0 has already been resolved to the CPU count by the CLI layer.
-    /// The parallel execution logic is not implemented yet; the value is plumbed
-    /// through so a follow-up can use it.
-    #[allow(dead_code)]
+    /// When greater than 1, spec files are executed in parallel using rayon.
     pub jobs: usize,
 }
 
@@ -27,10 +27,34 @@ impl RunCommand {
 
         self.initialise_workspace();
 
+        if self.jobs > 1 {
+            self.execute_parallel()
+        } else {
+            self.execute_sequential()
+        }
+    }
+
+    fn execute_sequential(&self) -> Vec<RunEvent> {
         self.spec_files
             .iter()
             .flat_map(|spec_file| self.run_spec_file(spec_file))
             .collect()
+    }
+
+    fn execute_parallel(&self) -> Vec<RunEvent> {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(self.jobs)
+            .build()
+            .expect("Failed to create thread pool for parallel execution");
+
+        let results: Vec<Vec<RunEvent>> = pool.install(|| {
+            self.spec_files
+                .par_iter()
+                .map(|spec_file| self.run_spec_file(spec_file))
+                .collect()
+        });
+
+        results.into_iter().flatten().collect()
     }
 
     fn initialise_workspace(&self) {
@@ -65,5 +89,229 @@ impl RunCommand {
 
     fn change_to_working_directory(&self) {
         std::env::set_current_dir(&self.working_dir).expect("Failed to set running directory");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::Output;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    /// A mock executor that always succeeds.
+    struct CountingExecutor {
+        #[allow(dead_code)]
+        call_count: AtomicUsize,
+    }
+
+    impl CountingExecutor {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Executor for CountingExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(Output {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(0),
+            })
+        }
+    }
+
+    /// A mock executor that always fails with a `CommandFailed` error.
+    struct FailingExecutor;
+
+    impl Executor for FailingExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            Err(Error::CommandFailed {
+                command: "mock-failing-command".to_string(),
+                message: "intentional failure for testing".to_string(),
+            })
+        }
+    }
+
+    fn write_spec_file(dir: &std::path::Path, name: &str, content: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, content).expect("Failed to write spec file");
+        path
+    }
+
+    const SIMPLE_SPEC: &str = "# Test Spec\n\n```shell,script(name=\"test\")\necho hello\n```\n";
+
+    fn make_run_command(
+        spec_files: Vec<PathBuf>,
+        executor: Box<dyn Executor>,
+        working_dir: PathBuf,
+        file_reader: FileReader,
+        jobs: usize,
+    ) -> RunCommand {
+        RunCommand {
+            spec_files,
+            executor,
+            working_dir,
+            workspace_init_command: None,
+            file_reader,
+            jobs,
+        }
+    }
+
+    /// Helper to run a closure with the CWD saved and restored,
+    /// since `RunCommand::execute()` calls `std::env::set_current_dir`.
+    fn with_saved_cwd<F: FnOnce() -> Vec<RunEvent>>(f: F) -> Vec<RunEvent> {
+        let original_dir = std::env::current_dir().expect("Failed to get current directory");
+        let events = f();
+        std::env::set_current_dir(&original_dir).expect("Failed to restore current directory");
+        events
+    }
+
+    #[test]
+    fn sequential_execution_runs_all_spec_files() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "spec1.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "spec2.md", SIMPLE_SPEC);
+        let executor = Box::new(CountingExecutor::new());
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+
+        let cmd = make_run_command(
+            vec![spec1.clone(), spec2.clone()],
+            executor,
+            dir.path().to_path_buf(),
+            file_reader,
+            1,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        // Each spec file produces: SpecFileStarted, TestCompleted(s), SpecFileCompleted
+        assert!(
+            events.len() >= 4,
+            "Should have events for both spec files, got {}",
+            events.len()
+        );
+
+        // Verify order: first event should be SpecFileStarted for spec1
+        match &events[0] {
+            RunEvent::SpecFileStarted(path) => {
+                assert_eq!(path.file_name().unwrap(), "spec1.md");
+            }
+            _ => panic!("Expected SpecFileStarted for spec1"),
+        }
+
+        // The second group should start with spec2
+        let spec2_start = events.iter().position(
+            |e| matches!(e, RunEvent::SpecFileStarted(p) if p.file_name().unwrap() == "spec2.md"),
+        );
+        assert!(
+            spec2_start.is_some(),
+            "Should find SpecFileStarted for spec2"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_preserves_file_order() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "a_spec.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "b_spec.md", SIMPLE_SPEC);
+        let spec3 = write_spec_file(dir.path(), "c_spec.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2, spec3],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        // Collect the SpecFileStarted events in order
+        let started_paths: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                RunEvent::SpecFileStarted(p) => Some(p.file_name().unwrap().to_owned()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            started_paths,
+            vec!["a_spec.md", "b_spec.md", "c_spec.md"],
+            "Parallel execution should preserve original file order"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_produces_nonzero_exit_when_any_spec_fails() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "passing.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "failing.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2],
+            Box::new(FailingExecutor),
+            dir.path().to_path_buf(),
+            file_reader,
+            2,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        // The failing executor causes ErrorOccurred events, which the exit_code
+        // module treats as errors (returns ErrorOccurred exit code).
+        use crate::commands::run::exit_code;
+        let exit_code = exit_code::from_events(&events);
+        assert_ne!(
+            exit_code as i32, 0,
+            "Exit code should be non-zero when any spec fails"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_with_single_spec_file() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec = write_spec_file(dir.path(), "only.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, RunEvent::SpecFileStarted(_))),
+            "Should have SpecFileStarted event"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, RunEvent::SpecFileCompleted { .. })),
+            "Should have SpecFileCompleted event"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_with_empty_spec_list() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+        assert!(events.is_empty(), "No spec files should produce no events");
     }
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -24,7 +24,7 @@ impl From<std::process::Output> for Output {
     }
 }
 
-pub trait Executor {
+pub trait Executor: Send + Sync {
     fn execute(&self, script: &ScriptCode) -> Result<Output, Error>;
 
     fn spawn(&self, script: &ScriptCode) -> Result<Child, Error> {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,5 +1,7 @@
 pub use error::Error;
 pub use executor::Executor;
+#[allow(unused_imports)]
+pub use executor::Output;
 pub use run_event::RunEvent;
 pub use runnable_action::to_runnable;
 pub use state::State;
@@ -78,16 +80,16 @@ mod tests {
         CreateFileAction, FileContent, FilePath, OutputExpectation, ScriptAction, ScriptCode,
         ScriptName,
     };
-    use std::cell::RefCell;
+    use std::sync::Mutex;
 
     struct MockExecutor {
-        output: RefCell<Option<Result<Output, Error>>>,
+        output: Mutex<Option<Result<Output, Error>>>,
     }
 
     impl MockExecutor {
         fn with_success(exit_code: Option<i32>, stdout: &str, stderr: &str) -> Self {
             Self {
-                output: RefCell::new(Some(Ok(Output {
+                output: Mutex::new(Some(Ok(Output {
                     stdout: stdout.to_string(),
                     stderr: stderr.to_string(),
                     exit_code,
@@ -97,7 +99,7 @@ mod tests {
 
         fn with_error(error: Error) -> Self {
             Self {
-                output: RefCell::new(Some(Err(error))),
+                output: Mutex::new(Some(Err(error))),
             }
         }
     }
@@ -105,7 +107,8 @@ mod tests {
     impl Executor for MockExecutor {
         fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
             self.output
-                .borrow_mut()
+                .lock()
+                .expect("mock executor mutex poisoned")
                 .take()
                 .expect("mock executor called more times than expected")
         }


### PR DESCRIPTION
## Summary

Implements parallel spec file execution using [rayon](https://github.com/rayon-rs/rayon) when `--jobs > 1`.

Builds on top of #596 which added the `--jobs/-j` CLI flag.

## Changes

- Add `rayon` dependency
- Add `Send + Sync` bounds to the `Executor` trait so executors can be shared across threads
- Update `MockExecutor` in runner tests to use `Mutex` instead of `RefCell` for thread safety
- Implement `RunCommand::execute_parallel()` using `rayon::ThreadPoolBuilder` and `par_iter()` to run spec files concurrently
- Results are collected in original file order (rayon preserves iteration order)
- Exit code is non-zero if ANY spec file fails (existing `exit_code::from_events` logic handles this)
- Add 5 unit tests: sequential execution, parallel order preservation, failure propagation, single file, empty list
- Extend `docs/specs/jobs_flag.md` with parallel execution acceptance tests

## How it works

When `--jobs > 1`, a rayon `ThreadPool` is created with the specified number of threads. Each spec file runs independently with its own `State` and `Runner` instance. The parallel iterator (`par_iter`) collects results into a `Vec<Vec<RunEvent>>` which is then flattened, preserving the original spec file order.

The `ShellExecutor` already uses `std::process::Command` which is thread-safe, so no changes were needed to support parallel mode. The `ContainerExecutor` (on the `feat/container-executor` branch) also uses `Send + Sync` types internally.

## Test plan

- [x] 172 unit tests pass (167 existing + 5 new)
- [x] `cargo clippy --tests -- -D warnings` is clean
- [x] `cargo fmt` applied
- [x] 14/14 specdown acceptance tests in `docs/specs/jobs_flag.md` pass
- [ ] CI green