### PR TITLE
feat: ordered output collection and thread-safe printing for parallel runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +641,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +828,7 @@ dependencies = [
  "num_cpus",
  "quickcheck",
  "quickcheck_macros",
+ "rayon",
  "shell-words",
  "strip-ansi-escapes",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,7 +419,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -434,6 +440,16 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -764,6 +780,7 @@ dependencies = [
  "indoc",
  "maplit",
  "nom",
+ "num_cpus",
  "quickcheck",
  "quickcheck_macros",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,10 @@ shell-words = "1.1.1"
 tempfile = "3.17.1"
 thiserror = "2.0.18"
 time = "0.3.37"
-
+num_cpus = "1.16"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"
 maplit = "1.0.2"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-tempfile = "3.17.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = "3.17.1"
 thiserror = "2.0.18"
 time = "0.3.37"
 num_cpus = "1.16"
+rayon = "1.10"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -417,6 +417,8 @@ Options:
           Unset an environment variable
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+  -j, --jobs <JOBS>
+          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
   -h, --help
           Print help
 ```
@@ -448,6 +450,8 @@ Options:
           Unset an environment variable
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+  -j, --jobs <JOBS>
+          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
   -h, --help
           Print help
 ```

--- a/docs/specs/jobs_flag.md
+++ b/docs/specs/jobs_flag.md
@@ -67,3 +67,53 @@ error: invalid value '-1' for '--jobs <JOBS>': -1 is not in 0..=4294967295
 
 For more information, try '--help'.
 ```
+
+## Parallel execution with multiple spec files
+
+When `--jobs > 1`, multiple spec files should run in parallel.
+We create two spec files and run them together with `-j 2`:
+
+~~~markdown,file(path="parallel_spec_a.md")
+# Spec A
+
+```shell,script(name="spec_a_test", expected_exit_code=0)
+echo "from spec a"
+```
+~~~
+
+~~~markdown,file(path="parallel_spec_b.md")
+# Spec B
+
+```shell,script(name="spec_b_test", expected_exit_code=0)
+echo "from spec b"
+```
+~~~
+
+```shell,script(name="parallel_multiple", expected_exit_code=0)
+specdown run -j 2 --temporary-workspace-dir parallel_spec_a.md parallel_spec_b.md
+```
+
+## Parallel execution preserves failure reporting
+
+When running multiple specs in parallel and one fails, the exit code
+should be non-zero:
+
+~~~markdown,file(path="passing_spec.md")
+# Passing Spec
+
+```shell,script(name="passing_test", expected_exit_code=0)
+echo ok
+```
+~~~
+
+~~~markdown,file(path="failing_spec.md")
+# Failing Spec
+
+```shell,script(name="failing_test", expected_exit_code=0)
+exit 1
+```
+~~~
+
+```shell,script(name="parallel_failure", expected_exit_code=1)
+specdown run -j 2 --temporary-workspace-dir passing_spec.md failing_spec.md
+```

--- a/docs/specs/jobs_flag.md
+++ b/docs/specs/jobs_flag.md
@@ -1,0 +1,69 @@
+# Jobs Flag
+
+The `--jobs` / `-j` flag controls how many specs can run in parallel.
+
+## Default value
+
+When `--jobs` is not specified, the default is `1` (sequential execution).
+
+```shell,script(name="jobs_default")
+specdown run --help 2>&1 | grep '\-\-jobs'
+```
+
+```text,verify(script_name="jobs_default")
+  -j, --jobs <JOBS>
+```
+
+## Test spec file
+
+We need a simple spec file to run the jobs flag against:
+
+~~~markdown,file(path="simple_spec.md")
+# Simple Spec
+
+```shell,script(name="simple_test",expected_exit_code=0)
+echo hello
+```
+
+```text,verify(script_name="simple_test")
+hello
+```
+~~~
+
+## Explicit job count
+
+Specifying `--jobs 4` should be accepted:
+
+```shell,script(name="jobs_explicit", expected_exit_code=0)
+specdown run --jobs 4 --temporary-workspace-dir simple_spec.md
+```
+
+## Short flag
+
+The `-j` short flag should also work:
+
+```shell,script(name="jobs_short", expected_exit_code=0)
+specdown run -j 2 --temporary-workspace-dir simple_spec.md
+```
+
+## Zero means parallel
+
+Specifying `-j 0` means "use all CPUs" and should be accepted:
+
+```shell,script(name="jobs_zero", expected_exit_code=0)
+specdown run -j 0 --temporary-workspace-dir simple_spec.md
+```
+
+## Negative values are rejected
+
+Negative values should produce an error:
+
+```shell,script(name="jobs_negative", expected_exit_code=2)
+specdown run --jobs -1 --temporary-workspace-dir simple_spec.md
+```
+
+```text,verify(script_name="jobs_negative", stream=stderr)
+error: invalid value '-1' for '--jobs <JOBS>': -1 is not in 0..=4294967295
+
+For more information, try '--help'.
+```

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -40,10 +40,7 @@ pub struct Arguments {
     #[clap(long)]
     pub add_path: Vec<String>,
 
-    /// Number of parallel jobs to run.
-    ///
-    /// Set to 0 to run all specs in parallel (uses the number of CPUs).
-    /// Defaults to 1 (sequential execution) for backward compatibility.
+    /// Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility)
     #[clap(short = 'j', long = "jobs", default_value_t = 1, allow_hyphen_values = true, value_parser = clap::value_parser!(u32).range(0..))]
     pub jobs: u32,
 }

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -39,4 +39,11 @@ pub struct Arguments {
     /// Adds the given directory to PATH
     #[clap(long)]
     pub add_path: Vec<String>,
+
+    /// Number of parallel jobs to run.
+    ///
+    /// Set to 0 to run all specs in parallel (uses the number of CPUs).
+    /// Defaults to 1 (sequential execution) for backward compatibility.
+    #[clap(short = 'j', long = "jobs", default_value_t = 1, allow_hyphen_values = true, value_parser = clap::value_parser!(u32).range(0..))]
+    pub jobs: u32,
 }

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -7,7 +7,6 @@ use run_command::RunCommand;
 use crate::config::Config;
 use crate::exit_codes::ExitCode;
 use crate::results::basic_printer::BasicPrinter;
-use crate::results::Printer;
 use crate::runner::shell_executor::ShellExecutor;
 use crate::runner::{Error, RunEvent};
 use crate::workspace::{ExistingDir, TemporaryDirectory, Workspace};
@@ -18,15 +17,14 @@ mod file_reader;
 mod run_command;
 
 pub fn execute(config: &Config, args: &Arguments) {
+    let printer = BasicPrinter::new(config.colour);
+    let printer_mutex =
+        std::sync::Mutex::new(Box::new(printer) as Box<dyn crate::results::Printer>);
+
     let events = create_run_command(args).map_or_else(
         |err| vec![RunEvent::ErrorOccurred(err)],
-        |command| command.execute(),
+        |command| command.execute_with_printer(&printer_mutex),
     );
-
-    let mut printer = BasicPrinter::new(config.colour);
-    for event in &events {
-        printer.print(event);
-    }
 
     let exit_code = exit_code::from_events(&events);
 

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -39,6 +39,13 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
     let shell_cmd = args.shell_command.clone();
     let mut env = parse_environment_variables(&args.env);
 
+    // Resolve jobs: 0 means "run all in parallel" — map to CPU count.
+    let jobs = if args.jobs == 0 {
+        num_cpus::get()
+    } else {
+        args.jobs as usize
+    };
+
     let unset_env = args.unset_env.clone();
     let paths = args.add_path.clone();
     let current_dir = std::env::current_dir().expect("Failed to get current workspace directory");
@@ -85,6 +92,7 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
         working_dir: actual_working_dir,
         workspace_init_command,
         file_reader,
+        jobs,
     };
 
     ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -22,7 +22,14 @@ pub fn execute(config: &Config, args: &Arguments) {
         std::sync::Mutex::new(Box::new(printer) as Box<dyn crate::results::Printer>);
 
     let events = create_run_command(args).map_or_else(
-        |err| vec![RunEvent::ErrorOccurred(err)],
+        |err| {
+            let events = vec![RunEvent::ErrorOccurred(err)];
+            let mut guard = printer_mutex.lock().expect("printer mutex poisoned");
+            for event in &events {
+                guard.print(event);
+            }
+            events
+        },
         |command| command.execute_with_printer(&printer_mutex),
     );
 

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -95,6 +95,7 @@ impl RunCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::run::exit_code;
     use crate::runner::Output;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::tempdir;
@@ -261,9 +262,6 @@ mod tests {
         );
         let events = with_saved_cwd(|| cmd.execute());
 
-        // The failing executor causes ErrorOccurred events, which the exit_code
-        // module treats as errors (returns ErrorOccurred exit code).
-        use crate::commands::run::exit_code;
         let exit_code = exit_code::from_events(&events);
         assert_ne!(
             exit_code as i32, 0,

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -12,6 +12,13 @@ pub struct RunCommand {
     pub working_dir: PathBuf,
     pub workspace_init_command: Option<String>,
     pub file_reader: FileReader,
+    /// The number of parallel jobs to use when running specs.
+    ///
+    /// A value of 0 has already been resolved to the CPU count by the CLI layer.
+    /// The parallel execution logic is not implemented yet; the value is plumbed
+    /// through so a follow-up can use it.
+    #[allow(dead_code)]
+    pub jobs: usize,
 }
 
 impl RunCommand {

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -159,13 +159,13 @@ mod tests {
                     guard.push_str(&format!("START: {}\n", path.display()));
                 }
                 RunEvent::SpecFileCompleted { success } => {
-                    guard.push_str(&format!("END: success={}\n", success));
+                    guard.push_str(&format!("END: success={success}\n"));
                 }
                 RunEvent::TestCompleted(result) => {
                     guard.push_str(&format!("TEST: success={}\n", result.success()));
                 }
                 RunEvent::ErrorOccurred(error) => {
-                    guard.push_str(&format!("ERROR: {}\n", error));
+                    guard.push_str(&format!("ERROR: {error}\n"));
                 }
             }
         }
@@ -432,7 +432,7 @@ mod tests {
         // is no other START line (no interleaving).
 
         for file_name in &["first.md", "second.md", "third.md"] {
-            let start_marker = format!("START: {}", file_name);
+            let start_marker = format!("START: {file_name}");
             let start_pos = captured_str
                 .find(file_name)
                 .unwrap_or_else(|| panic!("should find START for {}", file_name));

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use rayon::prelude::*;
 
 use crate::parsers;
+use crate::results::Printer;
 use crate::runner::{Error, Executor, RunEvent, Runner, State};
 use crate::types::ScriptCode;
 
@@ -22,26 +24,40 @@ pub struct RunCommand {
 }
 
 impl RunCommand {
-    pub fn execute(&self) -> Vec<RunEvent> {
+    /// Execute specs and print output via `printer` as results arrive.
+    ///
+    /// In parallel mode (`--jobs > 1`), each spec file's complete output is
+    /// printed atomically under a mutex lock as soon as that file finishes,
+    /// so output from different files never interleaves. A clear file header
+    /// introduces each spec file's results. The events are also returned in
+    /// original file order for exit-code computation.
+    pub fn execute_with_printer(&self, printer: &Mutex<Box<dyn Printer>>) -> Vec<RunEvent> {
         self.change_to_working_directory();
 
         self.initialise_workspace();
 
         if self.jobs > 1 {
-            self.execute_parallel()
+            self.execute_parallel_with_printer(printer)
         } else {
-            self.execute_sequential()
+            self.execute_sequential_with_printer(printer)
         }
     }
 
-    fn execute_sequential(&self) -> Vec<RunEvent> {
-        self.spec_files
-            .iter()
-            .flat_map(|spec_file| self.run_spec_file(spec_file))
-            .collect()
+    fn execute_sequential_with_printer(&self, printer: &Mutex<Box<dyn Printer>>) -> Vec<RunEvent> {
+        let mut all_events = Vec::new();
+        for spec_file in &self.spec_files {
+            let events = self.run_spec_file(spec_file);
+            let mut guard = printer.lock().expect("printer mutex poisoned");
+            for event in &events {
+                guard.print(event);
+            }
+            drop(guard);
+            all_events.extend(events);
+        }
+        all_events
     }
 
-    fn execute_parallel(&self) -> Vec<RunEvent> {
+    fn execute_parallel_with_printer(&self, printer: &Mutex<Box<dyn Printer>>) -> Vec<RunEvent> {
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(self.jobs)
             .build()
@@ -50,10 +66,21 @@ impl RunCommand {
         let results: Vec<Vec<RunEvent>> = pool.install(|| {
             self.spec_files
                 .par_iter()
-                .map(|spec_file| self.run_spec_file(spec_file))
+                .map(|spec_file| {
+                    let events = self.run_spec_file(spec_file);
+                    // Lock the printer so output from this spec file is printed
+                    // atomically and never interleaves with output from another.
+                    let mut guard = printer.lock().expect("printer mutex poisoned");
+                    for event in &events {
+                        guard.print(event);
+                    }
+                    events
+                })
                 .collect()
         });
 
+        // `par_iter().collect()` preserves original order, so flattening
+        // yields events in the original spec-file order.
         results.into_iter().flatten().collect()
     }
 
@@ -98,11 +125,58 @@ mod tests {
     use crate::commands::run::exit_code;
     use crate::runner::Output;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
 
+    /// A `Printer` that does nothing — used in tests that only need the
+    /// returned `Vec<RunEvent>` and don't care about printed output.
+    struct NullPrinter;
+
+    impl Printer for NullPrinter {
+        fn print(&mut self, _event: &RunEvent) {}
+    }
+
+    /// A `Printer` that captures all output into a string for assertions.
+    struct CapturingPrinter {
+        output: Arc<Mutex<String>>,
+    }
+
+    impl CapturingPrinter {
+        fn new_pair() -> (Self, Arc<Mutex<String>>) {
+            let output = Arc::new(Mutex::new(String::new()));
+            let printer = Self {
+                output: Arc::clone(&output),
+            };
+            (printer, output)
+        }
+    }
+
+    impl Printer for CapturingPrinter {
+        fn print(&mut self, event: &RunEvent) {
+            let mut guard = self.output.lock().expect("capture mutex poisoned");
+            match event {
+                RunEvent::SpecFileStarted(path) => {
+                    guard.push_str(&format!("START: {}\n", path.display()));
+                }
+                RunEvent::SpecFileCompleted { success } => {
+                    guard.push_str(&format!("END: success={}\n", success));
+                }
+                RunEvent::TestCompleted(result) => {
+                    guard.push_str(&format!("TEST: success={}\n", result.success()));
+                }
+                RunEvent::ErrorOccurred(error) => {
+                    guard.push_str(&format!("ERROR: {}\n", error));
+                }
+            }
+        }
+    }
+
+    fn null_printer() -> Mutex<Box<dyn Printer>> {
+        Mutex::new(Box::new(NullPrinter))
+    }
+
     /// A mutex to serialize tests that change the process-wide CWD
-    /// (`RunCommand::execute()` calls `std::env::set_current_dir`).
+    /// (`RunCommand::execute_with_printer()` calls `std::env::set_current_dir`).
     /// Without this, parallel test execution causes data races on the CWD.
     static CWD_MUTEX: Mutex<()> = Mutex::new(());
 
@@ -193,7 +267,8 @@ mod tests {
             file_reader,
             1,
         );
-        let events = with_saved_cwd(|| cmd.execute());
+        let printer = null_printer();
+        let events = with_saved_cwd(|| cmd.execute_with_printer(&printer));
 
         // Each spec file produces: SpecFileStarted, TestCompleted(s), SpecFileCompleted
         assert!(
@@ -235,7 +310,8 @@ mod tests {
             file_reader,
             4,
         );
-        let events = with_saved_cwd(|| cmd.execute());
+        let printer = null_printer();
+        let events = with_saved_cwd(|| cmd.execute_with_printer(&printer));
 
         // Collect the SpecFileStarted events in order
         let started_paths: Vec<_> = events
@@ -267,7 +343,8 @@ mod tests {
             file_reader,
             2,
         );
-        let events = with_saved_cwd(|| cmd.execute());
+        let printer = null_printer();
+        let events = with_saved_cwd(|| cmd.execute_with_printer(&printer));
 
         let exit_code = exit_code::from_events(&events);
         assert_ne!(
@@ -289,7 +366,8 @@ mod tests {
             file_reader,
             4,
         );
-        let events = with_saved_cwd(|| cmd.execute());
+        let printer = null_printer();
+        let events = with_saved_cwd(|| cmd.execute_with_printer(&printer));
 
         assert!(
             events
@@ -316,7 +394,131 @@ mod tests {
             file_reader,
             4,
         );
-        let events = with_saved_cwd(|| cmd.execute());
+        let printer = null_printer();
+        let events = with_saved_cwd(|| cmd.execute_with_printer(&printer));
         assert!(events.is_empty(), "No spec files should produce no events");
+    }
+
+    #[test]
+    fn parallel_output_does_not_interleave_between_files() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "first.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "second.md", SIMPLE_SPEC);
+        let spec3 = write_spec_file(dir.path(), "third.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2, spec3],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let (printer, output) = CapturingPrinter::new_pair();
+        let printer_mutex = Mutex::new(Box::new(printer) as Box<dyn Printer>);
+        let _events = with_saved_cwd(|| cmd.execute_with_printer(&printer_mutex));
+
+        let captured = output.lock().expect("capture mutex poisoned");
+        let captured_str = captured.as_str();
+
+        // Each file's output block should be contiguous — no interleaving.
+        // We check that "START: first" appears before any "START: second"
+        // or "START: third" is NOT guaranteed (files complete in arbitrary
+        // order), but each START..END block must be contiguous.
+        //
+        // Instead of asserting order (parallel completion order is
+        // nondeterministic), we verify that each file's START and END
+        // appear and that between a START and its corresponding END there
+        // is no other START line (no interleaving).
+
+        for file_name in &["first.md", "second.md", "third.md"] {
+            let start_marker = format!("START: {}", file_name);
+            let start_pos = captured_str
+                .find(file_name)
+                .unwrap_or_else(|| panic!("should find START for {}", file_name));
+
+            // Find the next START after this one
+            let rest_after_start = &captured_str[start_pos + start_marker.len()..];
+            let next_start = rest_after_start.find("START:");
+            // Find the END for this file — it's the first END after START
+            let end_pos = rest_after_start
+                .find("END:")
+                .unwrap_or_else(|| panic!("should find END after START for {}", file_name));
+
+            // The END must come before any other START (no interleaving)
+            if let Some(ns) = next_start {
+                assert!(
+                    end_pos < ns,
+                    "Output for {} interleaves with another file's START",
+                    file_name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parallel_output_includes_file_headers() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "alpha.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "beta.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let (printer, output) = CapturingPrinter::new_pair();
+        let printer_mutex = Mutex::new(Box::new(printer) as Box<dyn Printer>);
+        let _events = with_saved_cwd(|| cmd.execute_with_printer(&printer_mutex));
+
+        let captured = output.lock().expect("capture mutex poisoned");
+
+        // Both files should have their file paths in the output
+        assert!(
+            captured.contains("alpha.md"),
+            "Output should contain alpha.md file header, got: {:?}",
+            captured
+        );
+        assert!(
+            captured.contains("beta.md"),
+            "Output should contain beta.md file header, got: {:?}",
+            captured
+        );
+    }
+
+    #[test]
+    fn sequential_output_with_printer_prints_all_events() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "seq1.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "seq2.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            1,
+        );
+        let (printer, output) = CapturingPrinter::new_pair();
+        let printer_mutex = Mutex::new(Box::new(printer) as Box<dyn Printer>);
+        let _events = with_saved_cwd(|| cmd.execute_with_printer(&printer_mutex));
+
+        let captured = output.lock().expect("capture mutex poisoned");
+
+        // Sequential mode should print in order
+        let seq1_pos = captured
+            .find("seq1.md")
+            .expect("should find START for seq1");
+        let seq2_pos = captured
+            .find("seq2.md")
+            .expect("should find START for seq2");
+        assert!(
+            seq1_pos < seq2_pos,
+            "Sequential output should print seq1 before seq2"
+        );
     }
 }

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -98,7 +98,13 @@ mod tests {
     use crate::commands::run::exit_code;
     use crate::runner::Output;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    /// A mutex to serialize tests that change the process-wide CWD
+    /// (`RunCommand::execute()` calls `std::env::set_current_dir`).
+    /// Without this, parallel test execution causes data races on the CWD.
+    static CWD_MUTEX: Mutex<()> = Mutex::new(());
 
     /// A mock executor that always succeeds.
     struct CountingExecutor {
@@ -162,9 +168,10 @@ mod tests {
         }
     }
 
-    /// Helper to run a closure with the CWD saved and restored,
-    /// since `RunCommand::execute()` calls `std::env::set_current_dir`.
+    /// Run a closure while holding the CWD mutex, saving and restoring the
+    /// process-wide working directory around it.
     fn with_saved_cwd<F: FnOnce() -> Vec<RunEvent>>(f: F) -> Vec<RunEvent> {
+        let _guard = CWD_MUTEX.lock().expect("CWD mutex poisoned");
         let original_dir = std::env::current_dir().expect("Failed to get current directory");
         let events = f();
         std::env::set_current_dir(&original_dir).expect("Failed to restore current directory");

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
+
 use crate::parsers;
 use crate::runner::{Error, Executor, RunEvent, Runner, State};
 use crate::types::ScriptCode;
@@ -15,9 +17,7 @@ pub struct RunCommand {
     /// The number of parallel jobs to use when running specs.
     ///
     /// A value of 0 has already been resolved to the CPU count by the CLI layer.
-    /// The parallel execution logic is not implemented yet; the value is plumbed
-    /// through so a follow-up can use it.
-    #[allow(dead_code)]
+    /// When greater than 1, spec files are executed in parallel using rayon.
     pub jobs: usize,
 }
 
@@ -27,10 +27,34 @@ impl RunCommand {
 
         self.initialise_workspace();
 
+        if self.jobs > 1 {
+            self.execute_parallel()
+        } else {
+            self.execute_sequential()
+        }
+    }
+
+    fn execute_sequential(&self) -> Vec<RunEvent> {
         self.spec_files
             .iter()
             .flat_map(|spec_file| self.run_spec_file(spec_file))
             .collect()
+    }
+
+    fn execute_parallel(&self) -> Vec<RunEvent> {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(self.jobs)
+            .build()
+            .expect("Failed to create thread pool for parallel execution");
+
+        let results: Vec<Vec<RunEvent>> = pool.install(|| {
+            self.spec_files
+                .par_iter()
+                .map(|spec_file| self.run_spec_file(spec_file))
+                .collect()
+        });
+
+        results.into_iter().flatten().collect()
     }
 
     fn initialise_workspace(&self) {
@@ -65,5 +89,229 @@ impl RunCommand {
 
     fn change_to_working_directory(&self) {
         std::env::set_current_dir(&self.working_dir).expect("Failed to set running directory");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::Output;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    /// A mock executor that always succeeds.
+    struct CountingExecutor {
+        #[allow(dead_code)]
+        call_count: AtomicUsize,
+    }
+
+    impl CountingExecutor {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Executor for CountingExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(Output {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(0),
+            })
+        }
+    }
+
+    /// A mock executor that always fails with a `CommandFailed` error.
+    struct FailingExecutor;
+
+    impl Executor for FailingExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            Err(Error::CommandFailed {
+                command: "mock-failing-command".to_string(),
+                message: "intentional failure for testing".to_string(),
+            })
+        }
+    }
+
+    fn write_spec_file(dir: &std::path::Path, name: &str, content: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, content).expect("Failed to write spec file");
+        path
+    }
+
+    const SIMPLE_SPEC: &str = "# Test Spec\n\n```shell,script(name=\"test\")\necho hello\n```\n";
+
+    fn make_run_command(
+        spec_files: Vec<PathBuf>,
+        executor: Box<dyn Executor>,
+        working_dir: PathBuf,
+        file_reader: FileReader,
+        jobs: usize,
+    ) -> RunCommand {
+        RunCommand {
+            spec_files,
+            executor,
+            working_dir,
+            workspace_init_command: None,
+            file_reader,
+            jobs,
+        }
+    }
+
+    /// Helper to run a closure with the CWD saved and restored,
+    /// since `RunCommand::execute()` calls `std::env::set_current_dir`.
+    fn with_saved_cwd<F: FnOnce() -> Vec<RunEvent>>(f: F) -> Vec<RunEvent> {
+        let original_dir = std::env::current_dir().expect("Failed to get current directory");
+        let events = f();
+        std::env::set_current_dir(&original_dir).expect("Failed to restore current directory");
+        events
+    }
+
+    #[test]
+    fn sequential_execution_runs_all_spec_files() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "spec1.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "spec2.md", SIMPLE_SPEC);
+        let executor = Box::new(CountingExecutor::new());
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+
+        let cmd = make_run_command(
+            vec![spec1.clone(), spec2.clone()],
+            executor,
+            dir.path().to_path_buf(),
+            file_reader,
+            1,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        // Each spec file produces: SpecFileStarted, TestCompleted(s), SpecFileCompleted
+        assert!(
+            events.len() >= 4,
+            "Should have events for both spec files, got {}",
+            events.len()
+        );
+
+        // Verify order: first event should be SpecFileStarted for spec1
+        match &events[0] {
+            RunEvent::SpecFileStarted(path) => {
+                assert_eq!(path.file_name().unwrap(), "spec1.md");
+            }
+            _ => panic!("Expected SpecFileStarted for spec1"),
+        }
+
+        // The second group should start with spec2
+        let spec2_start = events.iter().position(
+            |e| matches!(e, RunEvent::SpecFileStarted(p) if p.file_name().unwrap() == "spec2.md"),
+        );
+        assert!(
+            spec2_start.is_some(),
+            "Should find SpecFileStarted for spec2"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_preserves_file_order() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "a_spec.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "b_spec.md", SIMPLE_SPEC);
+        let spec3 = write_spec_file(dir.path(), "c_spec.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2, spec3],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        // Collect the SpecFileStarted events in order
+        let started_paths: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                RunEvent::SpecFileStarted(p) => Some(p.file_name().unwrap().to_owned()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            started_paths,
+            vec!["a_spec.md", "b_spec.md", "c_spec.md"],
+            "Parallel execution should preserve original file order"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_produces_nonzero_exit_when_any_spec_fails() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec1 = write_spec_file(dir.path(), "passing.md", SIMPLE_SPEC);
+        let spec2 = write_spec_file(dir.path(), "failing.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec1, spec2],
+            Box::new(FailingExecutor),
+            dir.path().to_path_buf(),
+            file_reader,
+            2,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        // The failing executor causes ErrorOccurred events, which the exit_code
+        // module treats as errors (returns ErrorOccurred exit code).
+        use crate::commands::run::exit_code;
+        let exit_code = exit_code::from_events(&events);
+        assert_ne!(
+            exit_code as i32, 0,
+            "Exit code should be non-zero when any spec fails"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_with_single_spec_file() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let spec = write_spec_file(dir.path(), "only.md", SIMPLE_SPEC);
+
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![spec],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, RunEvent::SpecFileStarted(_))),
+            "Should have SpecFileStarted event"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, RunEvent::SpecFileCompleted { .. })),
+            "Should have SpecFileCompleted event"
+        );
+    }
+
+    #[test]
+    fn parallel_execution_with_empty_spec_list() {
+        let dir = tempdir().expect("Failed to create temp dir");
+        let file_reader = FileReader::new(dir.path().to_path_buf());
+        let cmd = make_run_command(
+            vec![],
+            Box::new(CountingExecutor::new()),
+            dir.path().to_path_buf(),
+            file_reader,
+            4,
+        );
+        let events = with_saved_cwd(|| cmd.execute());
+        assert!(events.is_empty(), "No spec files should produce no events");
     }
 }

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -124,6 +124,7 @@ mod tests {
     use super::*;
     use crate::commands::run::exit_code;
     use crate::runner::Output;
+    use std::fmt::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
@@ -156,16 +157,16 @@ mod tests {
             let mut guard = self.output.lock().expect("capture mutex poisoned");
             match event {
                 RunEvent::SpecFileStarted(path) => {
-                    guard.push_str(&format!("START: {}\n", path.display()));
+                    let _ = writeln!(guard, "START: {}", path.display());
                 }
                 RunEvent::SpecFileCompleted { success } => {
-                    guard.push_str(&format!("END: success={success}\n"));
+                    let _ = writeln!(guard, "END: success={success}");
                 }
                 RunEvent::TestCompleted(result) => {
-                    guard.push_str(&format!("TEST: success={}\n", result.success()));
+                    let _ = writeln!(guard, "TEST: success={}", result.success());
                 }
                 RunEvent::ErrorOccurred(error) => {
-                    guard.push_str(&format!("ERROR: {error}\n"));
+                    let _ = writeln!(guard, "ERROR: {error}");
                 }
             }
         }

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -21,7 +21,7 @@ struct Summary {
 }
 
 pub struct BasicPrinter {
-    display_function: Box<dyn Fn(&str)>,
+    display_function: Box<dyn Fn(&str) + Send + Sync>,
     summary: Summary,
     colour: bool,
 }
@@ -254,19 +254,19 @@ mod tests {
         CreateFileAction, ExitCode, FileContent, FilePath, OutputExpectation, ScriptAction,
         ScriptCode, ScriptName, Source, Stream, VerifyAction, VerifyValue,
     };
-    use std::cell::RefCell;
     use std::path::PathBuf;
-    use std::rc::Rc;
+    use std::sync::{Arc, Mutex};
 
     /// Helper that creates a `BasicPrinter` with no colour and captures
     /// everything written via the display function into a shared `String`.
-    fn create_capture_printer() -> (BasicPrinter, Rc<RefCell<String>>) {
-        let captured = Rc::new(RefCell::new(String::new()));
-        let captured_clone = captured.clone();
+    fn create_capture_printer() -> (BasicPrinter, Arc<Mutex<String>>) {
+        let captured = Arc::new(Mutex::new(String::new()));
+        let captured_clone = Arc::clone(&captured);
         let printer = BasicPrinter {
             display_function: Box::new(move |line: &str| {
-                captured_clone.borrow_mut().push_str(line);
-                captured_clone.borrow_mut().push('\n');
+                let mut guard = captured_clone.lock().expect("capture mutex poisoned");
+                guard.push_str(line);
+                guard.push('\n');
             }),
             summary: Summary {
                 number_succeeded: 0,
@@ -351,7 +351,7 @@ mod tests {
         };
         let event = RunEvent::ErrorOccurred(error);
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("nonexistent"),
             "print_error should display the error text containing the script name, got: {:?}",
@@ -391,7 +391,7 @@ mod tests {
             stderr: "my-stderr".to_string(),
         });
         printer.display_action_error(&error);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("my-stdout"),
             "display_action_error should show stdout, got: {:?}",
@@ -419,7 +419,7 @@ mod tests {
             stderr: "extra-err".to_string(),
         });
         printer.display_action_error(&error);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("extra-out"),
             "display_action_error should show stdout for unexpected output, got: {:?}",
@@ -438,7 +438,7 @@ mod tests {
     fn display_diff_shows_expected_vs_actual() {
         let (mut printer, captured) = create_capture_printer();
         printer.display_diff("expected line", "actual line");
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("==="),
             "display_diff should produce diff output with === separators, got: {:?}",
@@ -452,7 +452,7 @@ mod tests {
     fn disply_all_output_shows_stdout_and_stderr_sections() {
         let (mut printer, captured) = create_capture_printer();
         printer.disply_all_output("the-stdout", "the-stderr");
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("stdout:"),
             "disply_all_output should contain 'stdout:' header, got: {:?}",
@@ -481,7 +481,7 @@ mod tests {
     fn display_error_item_formats_with_cross_mark() {
         let (printer, captured) = create_capture_printer();
         printer.display_error_item("something went wrong");
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         // The cross mark ✓ is \u{2717}
         assert!(
             output.contains("\u{2717}"),
@@ -502,7 +502,7 @@ mod tests {
         let (printer, captured) = create_capture_printer();
         // In no-colour mode, the red ANSI codes are stripped
         printer.display_error("failure message");
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("failure message"),
             "display_error should contain the message text, got: {:?}",
@@ -580,7 +580,7 @@ mod tests {
     fn display_action_outputs_title_and_result_for_success() {
         let (mut printer, captured) = create_capture_printer();
         printer.display_action(&successful_script_result());
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         // display_action generates "{title} {result_message}" and wraps it in
         // display_success_item (check mark) or display_error_item (cross mark)
         assert!(
@@ -599,7 +599,7 @@ mod tests {
     fn display_action_outputs_title_and_result_for_failure() {
         let (mut printer, captured) = create_capture_printer();
         printer.display_action(&failed_exit_code_result());
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("bad_script"),
             "display_action should output the script name, got: {}",
@@ -622,7 +622,7 @@ mod tests {
         // Now start a new spec file — should reset
         let event = RunEvent::SpecFileStarted(PathBuf::from("test.md"));
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("test.md"),
             "print should show the file path, got: {:?}",
@@ -641,7 +641,7 @@ mod tests {
         printer2.count_action(&successful_script_result());
         let summary_event = RunEvent::SpecFileCompleted { success: true };
         printer2.print(&summary_event);
-        let output = captured2.borrow();
+        let output = captured2.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("1 succeeded"),
             "summary should say 1 succeeded, got: {:?}",
@@ -659,7 +659,7 @@ mod tests {
         let (mut printer, captured) = create_capture_printer();
         let event = RunEvent::TestCompleted(failed_exit_code_result());
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         // The result is a failure, so it should display error details with stdout/stderr
         assert!(
             output.contains("stdout:"),
@@ -678,7 +678,7 @@ mod tests {
         let (mut printer, captured) = create_capture_printer();
         let event = RunEvent::TestCompleted(failed_verify_result());
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("==="),
             "failed verify result should trigger diff display, got: {:?}",
@@ -694,7 +694,7 @@ mod tests {
         printer.count_action(&failed_exit_code_result());
         let event = RunEvent::SpecFileCompleted { success: false };
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("2 functions run"),
             "summary should say 2 functions run, got: {:?}",
@@ -717,7 +717,7 @@ mod tests {
         let (mut printer, captured) = create_capture_printer();
         let event = RunEvent::TestCompleted(failed_unexpected_output_result());
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         assert!(
             output.contains("stdout:"),
             "unexpected output error should show stdout section, got: {:?}",
@@ -732,11 +732,12 @@ mod tests {
 
     #[test]
     fn colour_mode_strips_ansi_escape_codes() {
-        let captured = Rc::new(RefCell::new(String::new()));
-        let captured_clone = captured.clone();
+        let captured = Arc::new(Mutex::new(String::new()));
+        let captured_clone = Arc::clone(&captured);
         let mut printer = BasicPrinter {
             display_function: Box::new(move |line: &str| {
-                captured_clone.borrow_mut().push_str(line);
+                let mut guard = captured_clone.lock().expect("capture mutex poisoned");
+                guard.push_str(line);
             }),
             summary: Summary {
                 number_succeeded: 0,
@@ -746,7 +747,7 @@ mod tests {
         };
         let event = RunEvent::TestCompleted(successful_script_result());
         printer.print(&event);
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         // In no-colour mode, crossterm's .green() / .red() / .blue() ANSI codes
         // are stripped, so there should be no ESC sequences
         assert!(
@@ -806,7 +807,7 @@ mod tests {
     fn display_success_item_formats_with_check_mark() {
         let (printer, captured) = create_capture_printer();
         printer.display_success_item("all good");
-        let output = captured.borrow();
+        let output = captured.lock().expect("capture mutex poisoned");
         // The check mark ✓ is \u{2713}
         assert!(
             output.contains("\u{2713}"),

--- a/src/results/printer.rs
+++ b/src/results/printer.rs
@@ -1,5 +1,5 @@
 use crate::runner::RunEvent;
 
-pub trait Printer {
+pub trait Printer: Send {
     fn print(&mut self, event: &RunEvent);
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -24,7 +24,7 @@ impl From<std::process::Output> for Output {
     }
 }
 
-pub trait Executor {
+pub trait Executor: Send + Sync {
     fn execute(&self, script: &ScriptCode) -> Result<Output, Error>;
 
     fn spawn(&self, script: &ScriptCode) -> Result<Child, Error> {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,5 +1,7 @@
 pub use error::Error;
 pub use executor::Executor;
+#[allow(unused_imports)]
+pub use executor::Output;
 pub use run_event::RunEvent;
 pub use runnable_action::to_runnable;
 pub use state::State;
@@ -78,16 +80,16 @@ mod tests {
         CreateFileAction, FileContent, FilePath, OutputExpectation, ScriptAction, ScriptCode,
         ScriptName,
     };
-    use std::cell::RefCell;
+    use std::sync::Mutex;
 
     struct MockExecutor {
-        output: RefCell<Option<Result<Output, Error>>>,
+        output: Mutex<Option<Result<Output, Error>>>,
     }
 
     impl MockExecutor {
         fn with_success(exit_code: Option<i32>, stdout: &str, stderr: &str) -> Self {
             Self {
-                output: RefCell::new(Some(Ok(Output {
+                output: Mutex::new(Some(Ok(Output {
                     stdout: stdout.to_string(),
                     stderr: stderr.to_string(),
                     exit_code,
@@ -97,7 +99,7 @@ mod tests {
 
         fn with_error(error: Error) -> Self {
             Self {
-                output: RefCell::new(Some(Err(error))),
+                output: Mutex::new(Some(Err(error))),
             }
         }
     }
@@ -105,7 +107,8 @@ mod tests {
     impl Executor for MockExecutor {
         fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
             self.output
-                .borrow_mut()
+                .lock()
+                .expect("mock executor mutex poisoned")
                 .take()
                 .expect("mock executor called more times than expected")
         }


### PR DESCRIPTION
## Summary

Implements ordered output handling for parallel spec execution.

- **Printer trait** is now  ()
- **BasicPrinter** uses  for its display function ()
- **Executor trait** has  bounds ()
- Test helpers migrated from  to  for thread safety
- Each spec file's output is printed atomically under a mutex lock in parallel mode, preventing interleaved output
- Output clearly indicates which spec file each result belongs to via file headers ( event)
- Events are returned in original file order for exit-code computation (rayon's `par_iter().collect()` preserves order)

## Test plan
- [x] `cargo test --bin specdown` — 175 unit tests pass
- [x] `cargo test --test command_test` — 14/15 integration tests pass (1 pre-existing failure in `test_doc_errors` unrelated to these changes)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean