### PR TITLE
fix: upgrade crossbeam-epoch to fix RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -167,7 +167,7 @@ Given `empty_spec.md`:
 Running the following command will fail:
 
 ```shell,script(name="empty_shell_command_example", expected_exit_code=2)
-specdown run --workspace-dir dirname --temporary-workspace-dir empty_shell_command_example.md
+specdown --no-colour run --workspace-dir dirname --temporary-workspace-dir empty_shell_command_example.md
 ```
 
 With the following error message:
@@ -189,7 +189,7 @@ Given `empty_shell_command_example.md`:
 Running the following command will fail:
 
 ```shell,script(name="empty_shell_command_example", expected_exit_code=2)
-specdown run --shell-command '' empty_shell_command_example.md
+specdown --no-colour run --shell-command '' empty_shell_command_example.md
 ```
 
 With the following error message:
@@ -209,7 +209,7 @@ Given `invalid_shell_command_example.md`:
 Running the following command will fail:
 
 ```shell,script(name="invalid_shell_command_example", expected_exit_code=2)
-specdown run --shell-command 'invalid " command' invalid_shell_command_example.md
+specdown --no-colour run --shell-command 'invalid " command' invalid_shell_command_example.md
 ```
 
 With the following error message:
@@ -233,7 +233,7 @@ echo "Hello world"
 Running the following command will fail:
 
 ```shell,script(name="missing_shell_example", expected_exit_code=2)
-specdown run --shell-command 'does-not-exist' missing_shell_example.md
+specdown --no-colour run --shell-command 'does-not-exist' missing_shell_example.md
 ```
 
 With the following error message:

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -127,10 +127,21 @@ fn test_doc_output_expectations() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_errors() {
+    let bin_dir = std::env::current_dir()
+        .expect("failed to get current directory")
+        .join("target")
+        .join("debug");
     let result = Command::cargo_bin("specdown")
         .unwrap()
+        .arg("--no-colour")
         .arg("run")
         .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(
+            bin_dir
+                .to_str()
+                .expect("failed to convert bin_dir to UTF-8 string"),
+        )
         .arg("docs/errors.md")
         .ok();
 


### PR DESCRIPTION
## Summary

Resolves the `cargo-audit` CI failure on master (run [#28897600654](https://github.com/specdown/specdown/actions/runs/28897600654)).

### Vulnerability
- **RUSTSEC-2026-0204**: `crossbeam-epoch` 0.9.18 — invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
- **Fix**: `cargo update -p crossbeam-epoch` → 0.9.20

### Also fixes
- `test_doc_errors` integration test — added `--no-colour` to specdown invocations in `docs/errors.md` and `--add-path` to the test so inner specdown calls find the freshly-built binary

### Test plan
- [x] `cargo test` — 16 integration + 172 unit tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo update -p crossbeam-epoch` — bumped to 0.9.20