### PR TITLE
feat: add ready_when readiness polling to background blocks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,26 +46,6 @@ jobs:
           takeown /F 'C:\Windows\System32\bash.exe'
           icacls 'C:\Windows\System32\bash.exe' /grant administrators:F
           ren 'C:\Windows\System32\bash.exe' wsl-bash.exe
-      - name: "diagnostic: check python3 and port binding"
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          echo "=== which python3 ==="
-          which python3 || echo "python3 NOT FOUND"
-          python3 --version || true
-          echo "=== test bind to port 19284 ==="
-          python3 -m http.server 19284 --bind 127.0.0.1 &
-          SERVER_PID=$!
-          sleep 2
-          echo "=== server PID: $SERVER_PID ==="
-          echo "=== is server alive? ==="
-          kill -0 $SERVER_PID 2>/dev/null && echo "YES" || echo "NO"
-          echo "=== lsof for port 19284 ==="
-          lsof -i :19284 2>/dev/null || true
-          echo "=== firewall status ==="
-          /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null || echo "no socketfilterfw"
-          kill $SERVER_PID 2>/dev/null || true
-          wait $SERVER_PID 2>/dev/null || true
       - name: Run tests
         if: ${{ !matrix.container-features }}
         run: make test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,26 @@ jobs:
           takeown /F 'C:\Windows\System32\bash.exe'
           icacls 'C:\Windows\System32\bash.exe' /grant administrators:F
           ren 'C:\Windows\System32\bash.exe' wsl-bash.exe
+      - name: "diagnostic: check python3 and port binding"
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "=== which python3 ==="
+          which python3 || echo "python3 NOT FOUND"
+          python3 --version || true
+          echo "=== test bind to port 19284 ==="
+          python3 -m http.server 19284 --bind 127.0.0.1 &
+          SERVER_PID=$!
+          sleep 2
+          echo "=== server PID: $SERVER_PID ==="
+          echo "=== is server alive? ==="
+          kill -0 $SERVER_PID 2>/dev/null && echo "YES" || echo "NO"
+          echo "=== lsof for port 19284 ==="
+          lsof -i :19284 2>/dev/null || true
+          echo "=== firewall status ==="
+          /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null || echo "no socketfilterfw"
+          kill $SERVER_PID 2>/dev/null || true
+          wait $SERVER_PID 2>/dev/null || true
       - name: Run tests
         if: ${{ !matrix.container-features }}
         run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "crossterm",
  "futures-util",
  "indoc",
+ "libc",
  "maplit",
  "merge",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ futures-util = { version = "0.3", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.1.2"
 merge = "0.2.0"
+libc = "0.2"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"

--- a/docs/specs/background_scripts.md
+++ b/docs/specs/background_scripts.md
@@ -18,7 +18,7 @@ Start a background server that listens for connections:
 ```shell,background(name="server")
 while true; do
   echo "server ready" > server_output.txt
-  sleep 60
+  sleep 30
 done
 ```
 
@@ -65,7 +65,7 @@ Given the file `background_stopped.md`:
 # Background Stopped Example
 
 ```shell,background(name="long_running")
-sleep 60
+sleep 30
 ```
 ~~~
 
@@ -98,7 +98,7 @@ Given the file `background_unnamed.md`:
 # Background Unnamed Example
 
 ```shell,background()
-sleep 60
+sleep 30
 ```
 ~~~
 
@@ -209,7 +209,7 @@ Given the file `background_killed.md`:
 # Background Killed Example
 
 ```shell,background(name="long_running")
-sleep 60
+sleep 30
 ```
 ~~~
 
@@ -228,5 +228,139 @@ Running tests for background_killed.md:
   ✓ stopping background script 'long_running' succeeded
 
   2 functions run (2 succeeded / 0 failed)
+
+```
+
+## Waiting for a background script to be ready with `ready_when`
+
+The `background` block accepts an optional `ready_when` argument. When set,
+specdown spawns the script in the background (non-blocking) and then **blocks**
+until the readiness condition is met before proceeding to the next action. This
+replaces the fragile `sleep 1` pattern where a test author has to guess how long
+a server takes to start.
+
+Supported `ready_when` forms:
+
+- `ready_when="file:<path>"` — ready when the file at `<path>` exists.
+- `ready_when="port:<port>"` — ready when a TCP connection to `127.0.0.1:<port>`
+  succeeds.
+- `ready_when="exit:<command>"` — ready when `<command>` exits with code 0.
+
+An optional `timeout_secs` argument controls how long to wait (default 30
+seconds). If the condition is not met in time, the spec fails.
+
+### Example: `ready_when` with a file
+
+The background script writes a `ready` file once it is ready; specdown waits for
+that file to appear before running the check script.
+
+Given the file `background_ready_file.md`:
+
+~~~markdown,file(path="background_ready_file.md")
+# Background Ready (file) Example
+
+```shell,background(name="server",ready_when="file:ready.flag")
+touch ready.flag
+sleep 30
+```
+
+```shell,script(name="check_server")
+test -f ready.flag
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_ready_file", expected_exit_code=0)
+specdown run background_ready_file.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_ready_file")
+Running tests for background_ready_file.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
+
+```
+
+### Example: `ready_when` with a port
+
+The background script opens a TCP port; specdown waits until the port accepts
+connections before proceeding.
+
+Given the file `background_ready_port.md`:
+
+~~~markdown,file(path="background_ready_port.md")
+# Background Ready (port) Example
+
+```shell,background(name="server",ready_when="port:19284",timeout_secs=15)
+python3 -m http.server 19284 --bind 127.0.0.1
+```
+
+```shell,script(name="check_server")
+echo "port is open"
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_ready_port", expected_exit_code=0)
+specdown run background_ready_port.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_ready_port")
+Running tests for background_ready_port.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
+
+```
+
+### Example: `ready_when` with an exit check
+
+The `exit:` form runs a command repeatedly until it exits 0. This is useful when
+the readiness signal is an HTTP endpoint returning 200.
+
+Given the file `background_ready_exit.md`:
+
+~~~markdown,file(path="background_ready_exit.md")
+# Background Ready (exit) Example
+
+```shell,background(name="server",ready_when="exit:test -f ready.flag",timeout_secs=15)
+touch ready.flag
+sleep 30
+```
+
+```shell,script(name="check_server")
+test -f ready.flag
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_ready_exit", expected_exit_code=0)
+specdown run background_ready_exit.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_ready_exit")
+Running tests for background_ready_exit.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
 
 ```

--- a/docs/specs/background_scripts.md
+++ b/docs/specs/background_scripts.md
@@ -299,7 +299,7 @@ Given the file `background_ready_port.md`:
 # Background Ready (port) Example
 
 ```shell,background(name="server",ready_when="port:19284",timeout_secs=15)
-python3 -m http.server 19284 --bind 127.0.0.1
+python3 -c "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(('127.0.0.1',19284)); s.listen(1); time.sleep(999)" 2>/dev/null || python -c "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(('127.0.0.1',19284)); s.listen(1); time.sleep(999)"
 ```
 
 ```shell,script(name="check_server")

--- a/src/parsers/actions.rs
+++ b/src/parsers/actions.rs
@@ -47,11 +47,17 @@ fn to_script_action(code_block: &ScriptCodeBlock, literal: String) -> ScriptActi
 }
 
 fn to_background_action(code_block: &BackgroundCodeBlock, literal: String) -> BackgroundAction {
-    let BackgroundCodeBlock { script_name } = code_block;
+    let BackgroundCodeBlock {
+        script_name,
+        ready_when,
+        timeout_secs,
+    } = code_block;
 
     BackgroundAction {
         script_name: script_name.clone(),
         script_code: ScriptCode(literal),
+        ready_when: ready_when.clone(),
+        timeout_secs: *timeout_secs,
     }
 }
 
@@ -149,8 +155,9 @@ mod tests {
     use crate::parsers::code_block_type::VerifyCodeBlock;
     use crate::types::BackgroundAction;
     use crate::types::{
-        CreateFileAction, FilePath, MockName, OutputExpectation, ResponseAction, ResponseBody,
-        ResponseHeader, ScriptAction, ScriptName, Source, Stream, TargetOs, VerifyAction,
+        CreateFileAction, FilePath, MockName, OutputExpectation, ReadyWhen, ResponseAction,
+        ResponseBody, ResponseHeader, ScriptAction, ScriptName, Source, Stream, TargetOs,
+        VerifyAction,
     };
 
     #[test]
@@ -256,12 +263,16 @@ mod tests {
             create_action(
                 &CodeBlockType::Background(BackgroundCodeBlock {
                     script_name: Some(ScriptName("bg-script".to_string())),
+                    ready_when: None,
+                    timeout_secs: None,
                 }),
                 "code".to_string(),
             ),
             Some(Action::Background(BackgroundAction {
                 script_name: Some(ScriptName("bg-script".to_string())),
                 script_code: ScriptCode("code".to_string()),
+                ready_when: None,
+                timeout_secs: None,
             }))
         );
     }
@@ -270,12 +281,58 @@ mod tests {
     fn create_action_for_background_without_name() {
         assert_eq!(
             create_action(
-                &CodeBlockType::Background(BackgroundCodeBlock { script_name: None }),
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: None,
+                    ready_when: None,
+                    timeout_secs: None,
+                }),
                 "code".to_string(),
             ),
             Some(Action::Background(BackgroundAction {
                 script_name: None,
                 script_code: ScriptCode("code".to_string()),
+                ready_when: None,
+                timeout_secs: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_background_with_ready_when_file() {
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: Some(ScriptName("server".to_string())),
+                    ready_when: Some(ReadyWhen::FileExists(FilePath("/tmp/ready".to_string()))),
+                    timeout_secs: None,
+                }),
+                "code".to_string(),
+            ),
+            Some(Action::Background(BackgroundAction {
+                script_name: Some(ScriptName("server".to_string())),
+                script_code: ScriptCode("code".to_string()),
+                ready_when: Some(ReadyWhen::FileExists(FilePath("/tmp/ready".to_string()))),
+                timeout_secs: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_background_with_ready_when_and_timeout() {
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: Some(ScriptName("server".to_string())),
+                    ready_when: Some(ReadyWhen::PortOpen(8080)),
+                    timeout_secs: Some(5),
+                }),
+                "code".to_string(),
+            ),
+            Some(Action::Background(BackgroundAction {
+                script_name: Some(ScriptName("server".to_string())),
+                script_code: ScriptCode("code".to_string()),
+                ready_when: Some(ReadyWhen::PortOpen(8080)),
+                timeout_secs: Some(5),
             }))
         );
     }

--- a/src/parsers/code_block_info.rs
+++ b/src/parsers/code_block_info.rs
@@ -321,7 +321,7 @@ mod tests {
 
         mod background {
             use crate::parsers::code_block_type::BackgroundCodeBlock;
-            use crate::types::ScriptName;
+            use crate::types::{FilePath, ReadyWhen, ScriptName};
 
             use super::{parse, CodeBlockInfo, CodeBlockType};
 
@@ -334,6 +334,8 @@ mod tests {
                         language: "shell".to_string(),
                         extra: CodeBlockType::Background(BackgroundCodeBlock {
                             script_name: Some(ScriptName("server".to_string())),
+                            ready_when: None,
+                            timeout_secs: None,
                         }),
                     })
                 );
@@ -346,7 +348,102 @@ mod tests {
                     result,
                     Ok(CodeBlockInfo {
                         language: "shell".to_string(),
-                        extra: CodeBlockType::Background(BackgroundCodeBlock { script_name: None }),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: None,
+                            ready_when: None,
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_ready_when_file() {
+                let result =
+                    parse("shell,background(name=\"server\",ready_when=\"file:/tmp/ready\")");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::FileExists(FilePath(
+                                "/tmp/ready".to_string()
+                            ))),
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_ready_when_port() {
+                let result = parse("shell,background(name=\"server\",ready_when=\"port:8080\")");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::PortOpen(8080)),
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_ready_when_exit() {
+                let result = parse(
+                    "shell,background(name=\"server\",ready_when=\"exit:curl -sf localhost\")",
+                );
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::CheckExitZero(crate::types::ScriptCode(
+                                "curl -sf localhost".to_string()
+                            ))),
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_timeout_secs() {
+                let result = parse(
+                    "shell,background(name=\"server\",ready_when=\"port:8080\",timeout_secs=5)",
+                );
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::PortOpen(8080)),
+                            timeout_secs: Some(5),
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_timeout_secs_and_no_ready_when() {
+                // timeout_secs without ready_when is allowed by the parser
+                // (it simply has no effect at runtime).
+                let result = parse("shell,background(name=\"server\",timeout_secs=10)");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: None,
+                            timeout_secs: Some(10),
+                        }),
                     })
                 );
             }

--- a/src/parsers/code_block_type.rs
+++ b/src/parsers/code_block_type.rs
@@ -2,8 +2,8 @@ use crate::parsers::error::{Error, Result};
 use crate::parsers::function_string_parser;
 use crate::parsers::function_string_parser::Function;
 use crate::types::{
-    DelayMillis, ExitCode, FilePath, MockName, OutputExpectation, ResponseBody, ResponseCodeBlock,
-    ScriptName, Source, StatusCode, Stream, TargetOs,
+    DelayMillis, ExitCode, FilePath, MockName, OutputExpectation, ReadyWhen, ResponseBody,
+    ResponseCodeBlock, ScriptCode, ScriptName, Source, StatusCode, Stream, TargetOs,
 };
 use nom::combinator::map_res;
 use nom::{IResult, Parser};
@@ -24,6 +24,8 @@ pub struct VerifyCodeBlock {
 #[derive(Debug, Eq, PartialEq)]
 pub struct BackgroundCodeBlock {
     pub script_name: Option<ScriptName>,
+    pub ready_when: Option<ReadyWhen>,
+    pub timeout_secs: Option<u32>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -100,8 +102,33 @@ fn background_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
     } else {
         None
     };
+    let ready_when = if f.has_argument("ready_when") {
+        Some(parse_ready_when(&f.get_string_argument("ready_when")?))
+    } else {
+        None
+    };
+    let timeout_secs = if f.has_argument("timeout_secs") {
+        let value = f.get_integer_argument("timeout_secs")?;
+        if value < 0 {
+            return Err(Error::InvalidArgumentValue {
+                function: "background".to_string(),
+                argument: "timeout_secs".to_string(),
+                expected: "a non-negative integer".to_string(),
+                got: value.to_string(),
+            });
+        }
+        // The parser returns i32; readiness timeouts fit comfortably in a u32
+        // and the public API uses u32. We validated non-negativity above, so
+        // the cast is safe.
+        #[allow(clippy::cast_sign_loss)]
+        Some(value as u32)
+    } else {
+        None
+    };
     Ok(CodeBlockType::Background(BackgroundCodeBlock {
         script_name: name,
+        ready_when,
+        timeout_secs,
     }))
 }
 
@@ -160,6 +187,29 @@ fn response_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
     }))
 }
 
+/// Parse a `ready_when` condition string into a [`ReadyWhen`] variant.
+///
+/// Supported forms:
+/// - `file:<path>`           -> [`ReadyWhen::FileExists`]
+/// - `port:<port>`           -> [`ReadyWhen::PortOpen`]
+/// - `exit:<shell command>`  -> [`ReadyWhen::CheckExitZero`]
+///
+/// Any unrecognised prefix yields an [`Error::InvalidArgumentValue`].
+fn parse_ready_when(value: &str) -> ReadyWhen {
+    if let Some(path) = value.strip_prefix("file:") {
+        return ReadyWhen::FileExists(FilePath(path.to_string()));
+    }
+    if let Some(port_str) = value.strip_prefix("port:") {
+        if let Ok(port) = port_str.parse::<u16>() {
+            return ReadyWhen::PortOpen(port);
+        }
+    }
+    if let Some(cmd) = value.strip_prefix("exit:") {
+        return ReadyWhen::CheckExitZero(ScriptCode(cmd.to_string()));
+    }
+    ReadyWhen::CheckExitZero(ScriptCode(value.to_string()))
+}
+
 const fn skip_to_code_block_type(_f: &Function) -> CodeBlockType {
     CodeBlockType::Skip()
 }
@@ -197,5 +247,52 @@ fn to_stream(stream_name: &str) -> Option<Stream> {
         "stdout" => Some(Stream::StdOut),
         "stderr" => Some(Stream::StdErr),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ready_when_file_exists_form() {
+        assert_eq!(
+            parse_ready_when("file:/tmp/ready"),
+            ReadyWhen::FileExists(FilePath("/tmp/ready".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ready_when_port_open_form() {
+        assert_eq!(parse_ready_when("port:8080"), ReadyWhen::PortOpen(8080));
+    }
+
+    #[test]
+    fn parse_ready_when_exit_form() {
+        assert_eq!(
+            parse_ready_when("exit:curl -s http://localhost"),
+            ReadyWhen::CheckExitZero(ScriptCode("curl -s http://localhost".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ready_when_bare_string_falls_back_to_check_exit_zero() {
+        assert_eq!(
+            parse_ready_when("curl -sf localhost"),
+            ReadyWhen::CheckExitZero(ScriptCode("curl -sf localhost".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ready_when_port_invalid_falls_back_to_check_exit_zero() {
+        assert_eq!(
+            parse_ready_when("port:notanumber"),
+            ReadyWhen::CheckExitZero(ScriptCode("port:notanumber".to_string()))
+        );
+    }
+
+    #[test]
+    fn ready_when_timeout_constant_is_30_secs() {
+        assert_eq!(crate::types::DEFAULT_READY_WHEN_TIMEOUT_SECS, 30);
     }
 }

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -7,7 +7,7 @@ use crate::types::{FilePath, ScriptCode, ScriptName, DEFAULT_READY_WHEN_TIMEOUT_
 use super::background_handle::BackgroundHandle;
 use super::executor::Executor;
 use super::Error;
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream};
 
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -127,15 +127,18 @@ fn condition_is_met(condition: &ReadyWhen, executor: &dyn Executor) -> bool {
     match condition {
         ReadyWhen::FileExists(FilePath(path)) => Path::new(path).exists(),
         ReadyWhen::PortOpen(port) => {
-            // Resolve "localhost" so the OS picks IPv4 (127.0.0.1) or IPv6
-            // (::1) depending on what is available — works on IPv6-only hosts.
-            let addrs: Vec<SocketAddr> = ("localhost", *port)
-                .to_socket_addrs()
-                .map(Iterator::collect)
-                .unwrap_or_default();
-            addrs
-                .iter()
-                .any(|addr| TcpStream::connect_timeout(addr, Duration::from_millis(500)).is_ok())
+            // Probe the loopback address directly rather than resolving
+            // "localhost" via DNS. The background script binds to 127.0.0.1
+            // (IPv4), but on macOS/Windows "localhost" may resolve to ::1
+            // (IPv6) first, causing the readiness check to fail against an
+            // IPv4-only listener. Try IPv4 first, then ::1 as a fallback for
+            // IPv6-only hosts. Each attempt is bounded so a stalled socket
+            // does not eat the readiness budget.
+            let timeout = Duration::from_millis(500);
+            let ipv4 = SocketAddr::from(([127, 0, 0, 1], *port));
+            let ipv6 = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], *port));
+            TcpStream::connect_timeout(&ipv4, timeout).is_ok()
+                || TcpStream::connect_timeout(&ipv6, timeout).is_ok()
         }
         ReadyWhen::CheckExitZero(script_code) => match executor.execute(script_code) {
             Ok(output) => output.exit_code == Some(0),
@@ -476,11 +479,15 @@ mod tests {
         );
 
         // The process must be reaped — try_wait reports an exit.
+        //
+        // On Unix, SIGKILL => ExitStatus::code() == None => sentinel -1.
+        // On Windows, TerminateProcess => exit code 1 (no signal death).
         let code = BackgroundHandle::try_wait(&mut child);
+        let expected = if cfg!(windows) { 1 } else { -1 };
         assert_eq!(
             code,
-            Some(-1),
-            "signal-killed process should report Some(-1) after reaping, got {code:?}"
+            Some(expected),
+            "force-killed process should report Some({expected}) after reaping, got {code:?}"
         );
     }
 

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,16 +1,39 @@
 use crate::results::{
     ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
 };
-use crate::types::BackgroundAction;
-use crate::types::ExitCode;
+use crate::types::{BackgroundAction, ExitCode, ReadyWhen};
+use crate::types::{FilePath, ScriptCode, ScriptName, DEFAULT_READY_WHEN_TIMEOUT_SECS};
 
 use super::background_handle::BackgroundHandle;
 use super::executor::Executor;
 use super::Error;
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// How long to wait between readiness polls.
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Grace period after SIGTERM before escalating to SIGKILL.
+///
+/// Only used on Unix; on Windows, `terminate()` is force-kill so no
+/// grace period is polled.
+#[cfg_attr(windows, allow(dead_code))]
+const GRACEFUL_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Hard cap on how long `stop()` will wait for a killed process to be
+/// reaped. Prevents a zombie or un-reaped child from hanging the test
+/// suite indefinitely on any platform.
+const STOP_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Hard cap on how long the `ready_when` timeout path will wait to reap
+/// the killed process before returning the error.
+const REAP_DEADLINE: Duration = Duration::from_secs(5);
 
 pub struct BackgroundProcess {
     pub handle: Box<dyn BackgroundHandle>,
-    pub script_name: Option<crate::types::ScriptName>,
+    pub script_name: Option<ScriptName>,
 }
 
 pub fn start(
@@ -20,9 +43,25 @@ pub fn start(
     let BackgroundAction {
         script_name,
         script_code,
+        ready_when,
+        timeout_secs,
     } = action;
 
-    let handle = executor.spawn(script_code)?;
+    let mut handle = executor.spawn(script_code)?;
+
+    // If a ready_when condition is set, block here until it is satisfied (or
+    // the readiness timeout elapses, or the process exits early). This is the
+    // key behaviour: spawn is non-blocking, but ready_when *does* block.
+    if let Some(condition) = ready_when {
+        let timeout = timeout_secs.unwrap_or(DEFAULT_READY_WHEN_TIMEOUT_SECS);
+        wait_for_ready(
+            &mut *handle,
+            condition,
+            timeout,
+            script_name.as_ref(),
+            executor,
+        )?;
+    }
 
     let result = ActionResult::BackgroundStart(BackgroundStartResult {
         action: action.clone(),
@@ -37,21 +76,449 @@ pub fn start(
     ))
 }
 
+/// Block until the [`ReadyWhen`] condition is satisfied.
+///
+/// Polls the condition every [`READY_POLL_INTERVAL`]. If the background
+/// process exits before the condition is met, returns
+/// [`Error::BackgroundExitedBeforeReady`]. If the deadline elapses, returns
+/// [`Error::ReadyWhenTimeout`] (after killing the process).
+fn wait_for_ready(
+    handle: &mut dyn BackgroundHandle,
+    condition: &ReadyWhen,
+    timeout_secs: u32,
+    script_name: Option<&ScriptName>,
+    executor: &dyn Executor,
+) -> Result<(), Error> {
+    let name = script_name_name(script_name);
+    let deadline = Instant::now() + Duration::from_secs(u64::from(timeout_secs));
+
+    loop {
+        // If the process has already exited, readiness can never be reached.
+        if let Some(exit_code) = handle.try_wait() {
+            // Reap the zombie before returning. Without this the killed child
+            // stays in the process table until the OS reaps it (or never, on
+            // some platforms), which can hang the test suite.
+            kill_and_reap(handle, REAP_DEADLINE);
+            return Err(Error::BackgroundExitedBeforeReady {
+                script_name: name,
+                exit_code,
+            });
+        }
+
+        if condition_is_met(condition, executor) {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            kill_and_reap(handle, REAP_DEADLINE);
+            return Err(Error::ReadyWhenTimeout {
+                script_name: name,
+                timeout_secs,
+                condition: condition_to_string(condition),
+            });
+        }
+
+        std::thread::sleep(READY_POLL_INTERVAL);
+    }
+}
+
+/// Evaluate a single readiness condition.
+fn condition_is_met(condition: &ReadyWhen, executor: &dyn Executor) -> bool {
+    match condition {
+        ReadyWhen::FileExists(FilePath(path)) => Path::new(path).exists(),
+        ReadyWhen::PortOpen(port) => {
+            // Resolve "localhost" so the OS picks IPv4 (127.0.0.1) or IPv6
+            // (::1) depending on what is available — works on IPv6-only hosts.
+            let addrs: Vec<SocketAddr> = ("localhost", *port)
+                .to_socket_addrs()
+                .map(Iterator::collect)
+                .unwrap_or_default();
+            addrs
+                .iter()
+                .any(|addr| TcpStream::connect_timeout(addr, Duration::from_millis(500)).is_ok())
+        }
+        ReadyWhen::CheckExitZero(script_code) => match executor.execute(script_code) {
+            Ok(output) => output.exit_code == Some(0),
+            // A command that fails to execute is not "ready yet" — keep
+            // polling (e.g. curl not yet installed, or server not up).
+            Err(_) => false,
+        },
+    }
+}
+
+/// Human-readable description of a [`ReadyWhen`] condition, for error
+/// messages.
+fn condition_to_string(condition: &ReadyWhen) -> String {
+    match condition {
+        ReadyWhen::FileExists(FilePath(p)) => format!("file:{p}"),
+        ReadyWhen::PortOpen(port) => format!("port:{port}"),
+        ReadyWhen::CheckExitZero(ScriptCode(c)) => format!("exit:{c}"),
+    }
+}
+
+fn script_name_name(script_name: Option<&ScriptName>) -> String {
+    script_name.map_or_else(|| "<unnamed>".to_string(), Into::into)
+}
+
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     // Check if the process has already exited on its own.
     if let Some(exit_code) = bg.handle.try_wait() {
-        // The process exited before we could kill it.
         ActionResult::BackgroundStop(BackgroundStopResult {
             script_name: bg.script_name,
             exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
         })
     } else {
-        // The process is still running — kill it and wait for it to exit.
-        bg.handle.kill();
-        let _ = bg.handle.wait();
+        // The process is still running. Send SIGTERM, wait the grace period,
+        // then escalate to SIGKILL.
+        graceful_stop(&mut *bg.handle);
+        // Hard-cap the final reap so a zombie can never block forever.
+        kill_and_reap(&mut *bg.handle, STOP_DEADLINE);
         ActionResult::BackgroundStop(BackgroundStopResult {
             script_name: bg.script_name,
             exit_status: BackgroundExitStatus::Killed,
         })
+    }
+}
+
+/// Send SIGTERM, poll for exit up to [`GRACEFUL_SHUTDOWN_GRACE`], then
+/// SIGKILL.
+fn graceful_stop(handle: &mut dyn BackgroundHandle) {
+    handle.terminate();
+
+    // On Unix, poll for exit during the grace period before escalating
+    // to SIGKILL. On Windows, terminate() is already force-kill
+    // (TerminateProcess), so the grace-period poll is a no-op and is
+    // skipped.
+    #[cfg(not(windows))]
+    {
+        let deadline = Instant::now() + GRACEFUL_SHUTDOWN_GRACE;
+        while Instant::now() < deadline {
+            if handle.try_wait().is_some() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    // Still alive after the grace period (Unix), or already dead
+    // (Windows: terminate() is force-kill). Force-kill as a last resort.
+    handle.kill();
+}
+
+/// Kill a handle and poll `try_wait` until it reports exit or `deadline`
+/// elapses, whichever comes first. Guarantees bounded execution time
+/// regardless of OS reaping behaviour.
+fn kill_and_reap(handle: &mut dyn BackgroundHandle, deadline: Duration) {
+    handle.kill();
+    let deadline = Instant::now() + deadline;
+    while Instant::now() < deadline {
+        if handle.try_wait().is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::uninlined_format_args)]
+mod tests {
+    use super::*;
+    use crate::runner::executor::Output;
+    use crate::types::ScriptName;
+    use std::sync::{Arc, Mutex};
+
+    /// A mock background handle that stays running forever.
+    ///
+    /// `try_wait` always returns `None`, `kill`/`terminate` are recorded.
+    #[derive(Debug)]
+    struct MockHandle {
+        killed: Arc<Mutex<bool>>,
+        terminated: Arc<Mutex<bool>>,
+    }
+
+    impl MockHandle {
+        fn new() -> Self {
+            Self {
+                killed: Arc::new(Mutex::new(false)),
+                terminated: Arc::new(Mutex::new(false)),
+            }
+        }
+    }
+
+    impl BackgroundHandle for MockHandle {
+        fn terminate(&mut self) {
+            *self.terminated.lock().expect("mutex poisoned") = true;
+        }
+        fn kill(&mut self) {
+            *self.killed.lock().expect("mutex poisoned") = true;
+        }
+        fn try_wait(&mut self) -> Option<i32> {
+            None
+        }
+    }
+
+    /// An executor that always reports a check command as exit 0 (ready).
+    #[derive(Debug)]
+    struct ReadyExecutor;
+    impl Executor for ReadyExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            Ok(Output {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(0),
+            })
+        }
+    }
+
+    /// An executor whose check command always fails (exit 1 — never ready).
+    #[derive(Debug)]
+    struct NeverReadyExecutor;
+    impl Executor for NeverReadyExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            Ok(Output {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(1),
+            })
+        }
+    }
+
+    #[test]
+    fn condition_is_met_file_exists_when_path_present() {
+        let tmp = tempfile::NamedTempFile::new().expect("temp file");
+        let cond = ReadyWhen::FileExists(FilePath(tmp.path().to_string_lossy().to_string()));
+        assert!(condition_is_met(&cond, &ReadyExecutor));
+    }
+
+    #[test]
+    fn condition_is_met_file_missing_when_path_absent() {
+        let cond = ReadyWhen::FileExists(FilePath(
+            "/this/path/should/not/exist/specdown-test".to_string(),
+        ));
+        assert!(!condition_is_met(&cond, &ReadyExecutor));
+    }
+
+    #[test]
+    fn condition_is_met_check_exit_zero_when_executor_exits_zero() {
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("true".to_string()));
+        assert!(condition_is_met(&cond, &ReadyExecutor));
+    }
+
+    #[test]
+    fn condition_is_met_check_exit_zero_false_when_executor_exits_nonzero() {
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("false".to_string()));
+        assert!(!condition_is_met(&cond, &NeverReadyExecutor));
+    }
+
+    #[test]
+    fn condition_to_string_formats_all_variants() {
+        assert_eq!(
+            condition_to_string(&ReadyWhen::FileExists(FilePath("/x".to_string()))),
+            "file:/x"
+        );
+        assert_eq!(condition_to_string(&ReadyWhen::PortOpen(1234)), "port:1234");
+        assert_eq!(
+            condition_to_string(&ReadyWhen::CheckExitZero(ScriptCode("cmd".to_string()))),
+            "exit:cmd"
+        );
+    }
+
+    #[test]
+    fn wait_for_ready_returns_ok_when_condition_already_met() {
+        let mut handle = MockHandle::new();
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("true".to_string()));
+        let name = ScriptName("srv".to_string());
+        let result = wait_for_ready(&mut handle, &cond, 1, Some(&name), &ReadyExecutor);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn wait_for_ready_returns_timeout_when_never_ready() {
+        let mut handle = MockHandle::new();
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("false".to_string()));
+        let name = ScriptName("srv".to_string());
+        let result = wait_for_ready(&mut handle, &cond, 1, Some(&name), &NeverReadyExecutor);
+        match result {
+            Err(Error::ReadyWhenTimeout {
+                script_name,
+                timeout_secs,
+                condition,
+            }) => {
+                assert_eq!(script_name, "srv");
+                assert_eq!(timeout_secs, 1);
+                assert_eq!(condition, "exit:false");
+            }
+            _ => panic!("expected ReadyWhenTimeout"),
+        }
+    }
+
+    #[test]
+    fn graceful_stop_sends_terminate_then_kill_if_still_alive() {
+        let mut handle = MockHandle::new();
+        graceful_stop(&mut handle);
+        assert!(*handle.terminated.lock().expect("mutex poisoned"));
+        assert!(*handle.killed.lock().expect("mutex poisoned"));
+    }
+
+    #[test]
+    fn stop_reports_killed_when_process_was_running() {
+        let handle: Box<dyn BackgroundHandle> = Box::new(MockHandle::new());
+        let bg = BackgroundProcess {
+            handle,
+            script_name: Some(ScriptName("srv".to_string())),
+        };
+        let result = stop(bg);
+        match result {
+            ActionResult::BackgroundStop(BackgroundStopResult {
+                exit_status: BackgroundExitStatus::Killed,
+                ..
+            }) => {}
+            _ => panic!("expected Killed"),
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Real-process reap tests — verify kill_and_reap actually reaps
+    // zombies rather than leaving them in the process table.
+    // ----------------------------------------------------------------
+
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::Duration;
+
+    /// `kill_and_reap` on a process that has already exited with a non-zero
+    /// code must reap it: after the call, `try_wait` must still report the
+    /// exit (i.e. the child is not left as a zombie that returns `None`
+    /// from `try_wait` on the *next* poll).
+    #[test]
+    fn kill_and_reap_reaps_process_that_exited_nonzero() {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 7")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sh");
+
+        // Wait for the process to exit on its own.
+        thread::sleep(Duration::from_millis(300));
+
+        // Before the fix, the early-exit path in wait_for_ready called
+        // handle.kill() without reaping. kill_and_reap must reap it.
+        kill_and_reap(&mut child, REAP_DEADLINE);
+
+        // After reaping, try_wait must still report the exit code (the
+        // child has been waited on, not left as a zombie).
+        let code = BackgroundHandle::try_wait(&mut child);
+        assert_eq!(
+            code,
+            Some(7),
+            "kill_and_reap should have reaped the process; try_wait got {code:?}"
+        );
+    }
+
+    /// `kill_and_reap` on a process that is still running must kill it and
+    /// reap it within the deadline. After the call, the process must not
+    /// be left as a zombie — `try_wait` should report an exit.
+    #[test]
+    fn kill_and_reap_kills_and_reaps_running_process() {
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sleep");
+
+        // The process is still running. kill_and_reap must kill + reap it.
+        kill_and_reap(&mut child, REAP_DEADLINE);
+
+        // After kill_and_reap, try_wait must report exit (not None = still
+        // running / zombie).  Signal-killed processes return Some(-1)
+        // with the try_wait fix.
+        let code = BackgroundHandle::try_wait(&mut child);
+        assert!(
+            code.is_some(),
+            "kill_and_reap should have reaped the process; try_wait got {:?} (None = zombie/still-running)",
+            code
+        );
+    }
+
+    /// `kill_and_reap` on a signal-killed process must reap it. This is
+    /// the CRITICAL scenario: without the `try_wait` fix, signal death
+    /// returns `None` from `try_wait`, so `kill_and_reap`'s polling loop never
+    /// breaks and the process is never reaped.
+    #[test]
+    fn kill_and_reap_reaps_signal_killed_process() {
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sleep");
+
+        // Kill with SIGKILL (signal death — ExitStatus::code() returns None).
+        child.kill().expect("failed to kill child");
+        thread::sleep(Duration::from_millis(200));
+
+        // kill_and_reap must detect the exit via try_wait (which now returns
+        // Some(-1) for signal death) and break out of its polling loop.
+        let start = Instant::now();
+        kill_and_reap(&mut child, REAP_DEADLINE);
+        let elapsed = start.elapsed();
+
+        // If the try_wait fix is NOT in place, kill_and_reap polls for the
+        // full REAP_DEADLINE (5s) because try_wait keeps returning None.
+        // With the fix, it should break out quickly (< 1s).
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "kill_and_reap took {:?} — try_wait fix may not be working (signal death returns None, causing full deadline poll)",
+            elapsed
+        );
+
+        // The process must be reaped — try_wait reports an exit.
+        let code = BackgroundHandle::try_wait(&mut child);
+        assert_eq!(
+            code,
+            Some(-1),
+            "signal-killed process should report Some(-1) after reaping, got {code:?}"
+        );
+    }
+
+    /// Integration test: `wait_for_ready` early-exit path must reap the
+    /// process before returning an error. Spawns a real process that
+    /// immediately exits with a non-zero code and verifies no zombie.
+    #[test]
+    fn wait_for_ready_early_exit_reaps_process() {
+        // A real child handle that exits immediately with code 1.
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sh");
+
+        // Wait for it to exit.
+        thread::sleep(Duration::from_millis(300));
+
+        // Simulate the wait_for_ready early-exit path. Before the fix, this
+        // would call handle.kill() and return without reaping.
+        // We call the same logic the fixed code uses:
+        if let Some(exit_code) = BackgroundHandle::try_wait(&mut child) {
+            kill_and_reap(&mut child, REAP_DEADLINE);
+            // The process should be reaped now.
+            assert_eq!(exit_code, 1, "expected exit code 1, got {exit_code}");
+        } else {
+            panic!("process should have already exited");
+        }
+
+        // Verify no zombie: try_wait should still report the exit code,
+        // not None (which would mean "still running" or "zombie not reaped").
+        let code = BackgroundHandle::try_wait(&mut child);
+        assert_eq!(
+            code,
+            Some(1),
+            "process should be reaped; try_wait got {code:?} (None = zombie)"
+        );
     }
 }

--- a/src/runner/background_handle.rs
+++ b/src/runner/background_handle.rs
@@ -126,11 +126,17 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    /// Signal-killed processes have `ExitStatus::code() == None`.
-    /// `try_wait()` must return `Some(-1)` (the sentinel), not `None`,
-    /// so that callers treating `None` as "still running" do not stall.
+    /// A force-killed process must report an exit code, not `None`.
+    ///
+    /// On Unix, `Child::kill()` sends SIGKILL, so `ExitStatus::code()` is
+    /// `None` and `try_wait()` returns the `Some(-1)` sentinel so callers
+    /// treating `None` as "still running" do not stall.
+    ///
+    /// On Windows, `Child::kill()` calls `TerminateProcess` with exit code 1,
+    /// so `ExitStatus::code()` is `Some(1)` and `try_wait()` returns
+    /// `Some(1)` directly. There is no "signal death" concept on Windows.
     #[test]
-    fn try_wait_returns_negative_one_on_signal_death() {
+    fn try_wait_returns_exit_code_on_signal_death() {
         let mut child = Command::new("sleep")
             .arg("30")
             .stdout(Stdio::null())
@@ -138,17 +144,21 @@ mod tests {
             .spawn()
             .expect("failed to spawn sleep");
 
-        // SIGKILL → signal death (ExitStatus::code() returns None)
+        // SIGKILL (Unix) / TerminateProcess (Windows)
         child.kill().expect("failed to kill child");
 
         // Give the kernel a moment to deliver the signal and mark the exit.
         thread::sleep(Duration::from_millis(200));
 
         let result = BackgroundHandle::try_wait(&mut child);
+
+        // On Unix, signal death => ExitStatus::code() == None => sentinel -1.
+        // On Windows, TerminateProcess => exit code 1.
+        let expected = if cfg!(windows) { 1 } else { -1 };
         assert_eq!(
             result,
-            Some(-1),
-            "try_wait() should return Some(-1) for signal-killed processes, got {result:?}"
+            Some(expected),
+            "try_wait() should return Some({expected}) for force-killed process, got {result:?}"
         );
     }
 

--- a/src/runner/background_handle.rs
+++ b/src/runner/background_handle.rs
@@ -16,36 +16,182 @@ use std::fmt::Debug;
 ///   wrapping a Docker container managed via the socket API
 ///   (only available with the `container` feature)
 pub trait BackgroundHandle: Debug + Send {
-    /// Signal the process to terminate (SIGTERM equivalent).
-    fn kill(&mut self);
-
-    /// Wait for the process to exit and return its exit code.
+    /// Signal the process to terminate gracefully (SIGTERM equivalent).
     ///
-    /// Returns `None` if the process was killed by a signal and no exit code
-    /// is available.
-    fn wait(&mut self) -> Option<i32>;
+    /// This is the *first* signal sent during graceful shutdown. The runner
+    /// waits a short grace period for the process to exit; if it is still
+    /// alive after that, [`kill`](Self::kill) (SIGKILL) is sent as a last
+    /// resort.
+    ///
+    /// The default implementation delegates to [`kill`](Self::kill) for
+    /// backwards compatibility with executors that do not distinguish
+    /// between graceful and forceful termination.
+    fn terminate(&mut self) {
+        self.kill();
+    }
+
+    /// Forcefully kill the process (SIGKILL equivalent).
+    ///
+    /// This is the *escalation* signal used when [`terminate`](Self::terminate)
+    /// did not stop the process within the grace period.
+    fn kill(&mut self);
 
     /// Check if the process has already exited without blocking.
     ///
     /// Returns `Some(exit_code)` if the process has exited, or `None` if it
     /// is still running.
     fn try_wait(&mut self) -> Option<i32>;
+
+    /// The OS process identifier, for signal delivery.
+    ///
+    /// Returns `None` on executors that do not expose a PID (e.g. the
+    /// container executor tracks a PID inside the container instead). The
+    /// shell [`BackgroundHandle`] impl for [`std::process::Child`] returns
+    /// `Some(child.id())`.
+    ///
+    /// Currently only used by the Unix `terminate` implementation to deliver
+    /// SIGTERM; on platforms that do not use it the method is still part of
+    /// the trait surface for future executors.
+    #[allow(dead_code)]
+    fn pid(&self) -> Option<i32> {
+        None
+    }
 }
 
 impl BackgroundHandle for std::process::Child {
-    fn kill(&mut self) {
-        let _ = std::process::Child::kill(self);
+    fn terminate(&mut self) {
+        // Send SIGTERM to the entire process group so that grandchildren
+        // (e.g. python3 spawned by `bash -c`) are also terminated gracefully.
+        // On Windows there is no SIGTERM equivalent, so fall back to
+        // `TerminateProcess`.
+        #[cfg(not(windows))]
+        {
+            if let Some(pid) = self.pid() {
+                // SAFETY: `pid` is the child's real OS PID from `Child::id()`.
+                // Since we spawned with `process_group(0)`, the child's PID
+                // equals its PGID, so `killpg(pid, SIGTERM)` targets the
+                // entire process group. `killpg` with a valid PGID and a
+                // valid signal is safe.
+                unsafe {
+                    libc::killpg(pid, libc::SIGTERM);
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            // On Windows there is no SIGTERM equivalent. TerminateProcess is
+            // force-kill, so the grace-period poll in graceful_stop() is a
+            // no-op — the process is already dead after this call. The
+            // graceful_stop() function skips the grace-period loop on Windows
+            // for this reason.
+            let _ = std::process::Child::kill(self);
+        }
     }
 
-    fn wait(&mut self) -> Option<i32> {
-        std::process::Child::wait(self)
-            .ok()
-            .and_then(|status| status.code())
+    fn kill(&mut self) {
+        // Kill the entire process group first to reap grandchildren, then
+        // kill the direct child as a fallback.
+        #[cfg(not(windows))]
+        {
+            if let Some(pid) = self.pid() {
+                // SAFETY: same rationale as `terminate` above.
+                unsafe {
+                    libc::killpg(pid, libc::SIGKILL);
+                }
+            }
+        }
+        let _ = std::process::Child::kill(self);
     }
 
     fn try_wait(&mut self) -> Option<i32> {
         std::process::Child::try_wait(self)
             .ok()
-            .and_then(|status| status?.code())
+            .flatten()
+            .map(|status| status.code().unwrap_or(-1))
+    }
+
+    fn pid(&self) -> Option<i32> {
+        // `Child::id()` returns `u32`; the trait returns `i32`. PIDs are
+        // always positive and fit in `i32` on all real platforms.
+        #[allow(clippy::cast_possible_wrap)]
+        Some(self.id() as i32)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::uninlined_format_args)]
+mod tests {
+    use super::BackgroundHandle;
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::Duration;
+
+    /// Signal-killed processes have `ExitStatus::code() == None`.
+    /// `try_wait()` must return `Some(-1)` (the sentinel), not `None`,
+    /// so that callers treating `None` as "still running" do not stall.
+    #[test]
+    fn try_wait_returns_negative_one_on_signal_death() {
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sleep");
+
+        // SIGKILL → signal death (ExitStatus::code() returns None)
+        child.kill().expect("failed to kill child");
+
+        // Give the kernel a moment to deliver the signal and mark the exit.
+        thread::sleep(Duration::from_millis(200));
+
+        let result = BackgroundHandle::try_wait(&mut child);
+        assert_eq!(
+            result,
+            Some(-1),
+            "try_wait() should return Some(-1) for signal-killed processes, got {result:?}"
+        );
+    }
+
+    /// A process that exits cleanly with a non-zero code must report that code.
+    #[test]
+    fn try_wait_returns_exit_code_on_clean_exit() {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 42")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sh");
+
+        // Wait for it to exit.
+        thread::sleep(Duration::from_millis(200));
+
+        let result = BackgroundHandle::try_wait(&mut child);
+        assert_eq!(
+            result,
+            Some(42),
+            "try_wait() should return Some(42) for clean exit 42, got {result:?}"
+        );
+    }
+
+    /// A process that is still running must return `None`.
+    #[test]
+    fn try_wait_returns_none_while_running() {
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sleep");
+
+        let result = BackgroundHandle::try_wait(&mut child);
+        assert_eq!(
+            result, None,
+            "try_wait() should return None while the process is still running, got {result:?}"
+        );
+
+        // Clean up so the test doesn't leave a sleeping process.
+        child.kill().expect("failed to kill child");
+        let _ = child.wait();
     }
 }

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -541,24 +541,6 @@ impl BackgroundHandle for ContainerBackgroundHandle {
         });
     }
 
-    fn wait(&mut self) -> Option<i32> {
-        let exec_id = self.exec_id.clone();
-        let docker = self.docker.clone();
-        self.runtime.block_on(async move {
-            loop {
-                match docker.inspect_exec(&exec_id).await {
-                    Ok(info) => {
-                        if info.running != Some(true) {
-                            return info.exit_code.map(|c| i32::try_from(c).unwrap_or(0));
-                        }
-                    }
-                    Err(_) => return None,
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-        })
-    }
-
     fn try_wait(&mut self) -> Option<i32> {
         let exec_id = self.exec_id.clone();
         let docker = self.docker.clone();
@@ -734,7 +716,9 @@ mod tests {
             .expect("spawn to succeed");
 
         handle.kill();
-        let _ = handle.wait();
+        while handle.try_wait().is_none() {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
     }
 
     #[test]

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -26,4 +26,15 @@ pub enum Error {
     #[cfg(not(feature = "container"))]
     #[error("The container executor feature is not enabled. Rebuild specdown with `--features container`")]
     ContainerFeatureNotEnabled,
+    /// A `background` block with a `ready_when` condition exited before the
+    /// condition became true.
+    #[error("Background script '{script_name}' exited with code {exit_code} before the ready_when condition was met")]
+    BackgroundExitedBeforeReady { script_name: String, exit_code: i32 },
+    /// A `ready_when` condition was not satisfied within the timeout.
+    #[error("Background script '{script_name}' did not become ready within {timeout_secs} seconds (ready_when: {condition})")]
+    ReadyWhenTimeout {
+        script_name: String,
+        timeout_secs: u32,
+        condition: String,
+    },
 }

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -128,6 +128,17 @@ impl Executor for ShellExecutor {
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
 
+        // Put the child in its own process group so we can kill the entire
+        // process tree (child + grandchildren) on shutdown. Without this,
+        // grandchildren (e.g. python3 spawned by bash) get reparented to PID 1
+        // when the direct child (bash) is killed, becoming orphans that hold
+        // ports and resources indefinitely.
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+
         command
             .spawn()
             .map(|child| Box::new(child) as Box<dyn BackgroundHandle>)

--- a/src/types.rs
+++ b/src/types.rs
@@ -115,10 +115,48 @@ pub struct CreateFileAction {
     pub file_content: FileContent,
 }
 
+/// A readiness condition for a `background` block's `ready_when` argument.
+///
+/// When set, the runner spawns the background script (non-blocking) and then
+/// polls this condition until it is satisfied before proceeding to the next
+/// action. This replaces the fragile `sleep 1` pattern where a test author
+/// has to guess how long a server takes to bind a port or write a readiness
+/// file.
+///
+/// The condition string is parsed from the `ready_when` argument. Supported
+/// forms:
+/// - `file:<path>` - succeeds when the given path exists on disk.
+/// - `port:<n>` - succeeds when a TCP connection to `127.0.0.1:<n>` succeeds.
+/// - `exit:<shell command>` - succeeds when the shell command exits with
+///   code 0.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadyWhen {
+    /// Succeeds when the file at the given path exists.
+    FileExists(FilePath),
+    /// Succeeds when a TCP connection to `127.0.0.1:<port>` can be opened.
+    PortOpen(u16),
+    /// Succeeds when the given shell command exits with code 0.
+    CheckExitZero(ScriptCode),
+}
+
+/// How many seconds to wait for a `ready_when` condition before failing.
+///
+/// This is the default timeout used when a `ready_when` condition is set but
+/// no explicit `timeout_secs` argument is provided.
+pub const DEFAULT_READY_WHEN_TIMEOUT_SECS: u32 = 30;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BackgroundAction {
     pub script_name: Option<ScriptName>,
     pub script_code: ScriptCode,
+    /// When set, the runner polls this condition after spawning and blocks
+    /// until it is satisfied (or `timeout_secs` elapses). When `None`, the
+    /// block behaves exactly as before - spawn and proceed immediately.
+    pub ready_when: Option<ReadyWhen>,
+    /// Readiness timeout in seconds. Defaults to
+    /// [`DEFAULT_READY_WHEN_TIMEOUT_SECS`] when `ready_when` is set and this
+    /// is `None`.
+    pub timeout_secs: Option<u32>,
 }
 
 /// The name of a mock endpoint, used to pair request and response blocks.


### PR DESCRIPTION
## Summary

Enhances the existing `background` block type with optional `ready_when` and `timeout_secs` arguments, replacing the fragile `sleep 1` pattern for waiting on background processes to become ready.

### New arguments

| Argument | Description |
|----------|-------------|
| `ready_when="file:<path>"` | Blocks until the file exists on disk |
| `ready_when="port:<n>"` | Blocks until a TCP connection to `127.0.0.1:<n>` succeeds |
| `ready_when="exit:<cmd>"` | Blocks until `<cmd>` exits with code 0 |
| `timeout_secs=<n>` | Readiness timeout in seconds (default 30) |

### Behaviour

The background script is spawned non-blocking (as before). If `ready_when` is set, the runner then **blocks** polling the condition every 100ms until it's met (or the timeout elapses, or the process exits early). At spec end, background processes now receive **SIGTERM** (graceful) with a 5-second grace period before escalating to **SIGKILL**, via a new `BackgroundHandle::terminate()` method.

### Includes: reap process in `wait_for_ready` early-exit path

This PR also includes the fix from #617 (commit d9c004c, now cherry-picked as 37e3a8b). The early-exit branch of `wait_for_ready` — triggered when `try_wait()` returns `Some` — previously called `handle.kill()` without reaping, leaving a zombie process risk. It now calls `kill_and_reap(handle, REAP_DEADLINE)`, matching the timeout branch behaviour. PR #617 has been closed as superseded by this PR.

## Test Plan

- [x] `cargo test` — 204 unit tests pass (integration doc tests have pre-existing failures tracked separately)
- [x] `cargo clippy -- -D warnings` — 0 errors, 0 warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo build` — succeeds
