### PR TITLE
feat: add response block type for HTTP API mocking

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,17 +13,7 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v5
-        name: Cache cargo dependencies
-        with:
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          path: |
-            .cache
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
       - name: Audit check cargo packages
@@ -46,17 +36,13 @@ jobs:
         run: |
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           brew --prefix rustup 2>/dev/null && echo "$(brew --prefix rustup)/bin" >> $GITHUB_PATH || true
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v5
-        name: Cache cargo dependencies
-        with:
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          path: |
-            .cache
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: "workaround: Remove cached x86_64 rustup from PATH on ARM Linux"
+        if: runner.arch == 'ARM64' && runner.os == 'Linux'
+        shell: bash
+        run: |
+          CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
+          echo "PATH=$CLEAN_PATH" >> $GITHUB_ENV
+      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |
@@ -73,19 +59,9 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v5
-        name: Cache cargo dependencies
+      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          path: |
-            .cache
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt, clippy
+          rust-components: rustfmt, clippy
       - name: Run checks
         run: make check
       - name: Check markdown links

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,17 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
-      - name: "workaround: Clear cached wrong-arch rustup bin"
-        if: runner.os != 'Windows'
-        shell: bash
-        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
-      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v5
+        name: Cache cargo dependencies
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            .cache
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
       - name: Audit check cargo packages
@@ -40,17 +46,17 @@ jobs:
         run: |
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           brew --prefix rustup 2>/dev/null && echo "$(brew --prefix rustup)/bin" >> $GITHUB_PATH || true
-      - name: "workaround: Remove cached x86_64 rustup from PATH on ARM Linux"
-        if: runner.arch == 'ARM64' && runner.os == 'Linux'
-        shell: bash
-        run: |
-          CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
-          echo "PATH=$CLEAN_PATH" >> $GITHUB_ENV
-      - name: "workaround: Clear cached wrong-arch rustup bin"
-        if: runner.os != 'Windows'
-        shell: bash
-        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
-      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v5
+        name: Cache cargo dependencies
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            .cache
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Rename wsl bash
         if: runner.os == 'Windows'
         run: |
@@ -67,13 +73,19 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
     steps:
-      - name: "workaround: Clear cached wrong-arch rustup bin"
-        if: runner.os != 'Windows'
-        shell: bash
-        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
-      - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v5
+        name: Cache cargo dependencies
         with:
-          rust-components: rustfmt, clippy
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            .cache
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
       - name: Run checks
         run: make check
       - name: Check markdown links

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,10 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
+      - name: "workaround: Clear cached wrong-arch rustup bin"
+        if: runner.os != 'Windows'
+        shell: bash
+        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
       - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
@@ -42,6 +46,10 @@ jobs:
         run: |
           CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '\.cargo/bin' | tr '\n' ':' | sed 's/:$//')
           echo "PATH=$CLEAN_PATH" >> $GITHUB_ENV
+      - name: "workaround: Clear cached wrong-arch rustup bin"
+        if: runner.os != 'Windows'
+        shell: bash
+        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
       - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
       - name: Rename wsl bash
         if: runner.os == 'Windows'
@@ -59,6 +67,10 @@ jobs:
           - os: ubuntu-latest
           - os: windows-latest
     steps:
+      - name: "workaround: Clear cached wrong-arch rustup bin"
+        if: runner.os != 'Windows'
+        shell: bash
+        run: rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" || true
       - uses: tomphp/github-actions/checkout-rust-project@v0.8.1
         with:
           rust-components: rustfmt, clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,10 +90,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -99,6 +120,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "caseless"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,10 +207,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -220,29 +328,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
+name = "core-foundation-sys"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
@@ -274,12 +363,32 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -295,9 +404,9 @@ checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -305,13 +414,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "env_filter",
  "log",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -330,10 +445,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -360,6 +541,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,10 +565,276 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -393,22 +852,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jetscii"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
-name = "libc"
-version = "0.2.161"
+name = "js-sys"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -444,7 +926,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -467,13 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
+name = "num-traits"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "hermit-abi 0.5.2",
- "libc",
+ "autocfg",
 ]
 
 [[package]]
@@ -504,6 +985,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -542,6 +1029,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -611,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -641,32 +1143,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -724,6 +1226,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +1274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -759,10 +1298,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -807,35 +1407,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "specdown"
 version = "1.5.3"
 dependencies = [
  "assert_cmd",
+ "bollard",
  "clap",
  "clap_complete_command",
  "clap_derive",
  "comrak",
  "crossterm",
+ "futures-util",
  "indoc",
  "maplit",
  "nom",
- "num_cpus",
  "quickcheck",
  "quickcheck_macros",
- "rayon",
  "shell-words",
  "strip-ansi-escapes",
  "tempfile",
  "termdiff",
  "thiserror",
  "time",
+ "tokio",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -861,6 +1484,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -924,6 +1558,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -931,6 +1566,26 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tinyvec"
@@ -946,6 +1601,77 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-arena"
@@ -967,6 +1693,24 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -993,6 +1737,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1758,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1028,6 +1826,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1063,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1251,3 +2117,92 @@ checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.4.1",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +588,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -926,7 +957,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -955,6 +986,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
 ]
 
 [[package]]
@@ -1141,6 +1182,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1443,8 +1504,10 @@ dependencies = [
  "indoc",
  "maplit",
  "nom",
+ "num_cpus",
  "quickcheck",
  "quickcheck_macros",
+ "rayon",
  "shell-words",
  "strip-ansi-escapes",
  "tempfile",
@@ -1569,9 +1632,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ categories = [
 ]
 keywords = [ "markdown", "testing", "bdd", "tdd", "documentation" ]
 
+[features]
+default = []
+# Enables the container executor, which runs spec scripts inside a Docker
+# container via the Docker Engine API (socket).  When this feature is off,
+# specdown builds and runs without any Docker dependency.
+container = ["dep:bollard", "dep:tokio", "dep:futures-util"]
+
 [dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
 clap_derive = "4.1.8"
@@ -29,6 +36,12 @@ thiserror = "2.0.18"
 time = "0.3.37"
 num_cpus = "1.16"
 rayon = "1.10"
+
+# Container executor support (Docker socket API) — optional, behind the
+# `container` feature so the default build has no Docker dependency.
+bollard = { version = "0.18", default-features = false, features = ["http", "pipe"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "process", "io-util", "macros"], optional = true }
+futures-util = { version = "0.3", optional = true }
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -427,8 +427,11 @@ Options:
 
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+
   -j, --jobs <JOBS>
-          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
+          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility)
+          
+          [default: 1]
 
       --executor <EXECUTOR>
           The executor to use for running scripts.
@@ -446,13 +449,13 @@ Options:
           
           Ignored when the shell executor is used.
 
-
       --container-volume <HOST:CONTAINER[:OPTIONS]>
           Mount a host directory into the container (repeatable).
           
           Uses Docker CLI bind-mount syntax: `<host_path>:<container_path>[:options]`. For example, `--container-volume /host/data:/data` mounts the host directory `/host/data` at `/data` inside the container. Append `:ro` for a read-only mount.
           
           Only effective with `--executor container`.
+
   -h, --help
           Print help (see a summary with '-h')
 ```
@@ -494,8 +497,11 @@ Options:
 
       --add-path <ADD_PATH>
           Adds the given directory to PATH
+
   -j, --jobs <JOBS>
-          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
+          Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility)
+          
+          [default: 1]
 
       --executor <EXECUTOR>
           The executor to use for running scripts.
@@ -513,13 +519,13 @@ Options:
           
           Ignored when the shell executor is used.
 
-
       --container-volume <HOST:CONTAINER[:OPTIONS]>
           Mount a host directory into the container (repeatable).
           
           Uses Docker CLI bind-mount syntax: `<host_path>:<container_path>[:options]`. For example, `--container-volume /host/data:/data` mounts the host directory `/host/data` at `/data` inside the container. Append `:ro` for a read-only mount.
           
           Only effective with `--executor container`.
+
   -h, --help
           Print help (see a summary with '-h')
 ```

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -445,6 +445,14 @@ Options:
           The Docker image to use when `--executor container` is selected.
           
           Ignored when the shell executor is used.
+
+
+      --container-volume <HOST:CONTAINER[:OPTIONS]>
+          Mount a host directory into the container (repeatable).
+          
+          Uses Docker CLI bind-mount syntax: `<host_path>:<container_path>[:options]`. For example, `--container-volume /host/data:/data` mounts the host directory `/host/data` at `/data` inside the container. Append `:ro` for a read-only mount.
+          
+          Only effective with `--executor container`.
   -h, --help
           Print help (see a summary with '-h')
 ```
@@ -504,6 +512,14 @@ Options:
           The Docker image to use when `--executor container` is selected.
           
           Ignored when the shell executor is used.
+
+
+      --container-volume <HOST:CONTAINER[:OPTIONS]>
+          Mount a host directory into the container (repeatable).
+          
+          Uses Docker CLI bind-mount syntax: `<host_path>:<container_path>[:options]`. For example, `--container-volume /host/data:/data` mounts the host directory `/host/data` at `/data` inside the container. Append `:ro` for a read-only mount.
+          
+          Only effective with `--executor container`.
   -h, --help
           Print help (see a summary with '-h')
 ```

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -398,29 +398,55 @@ Runs a given Markdown Specification
 Usage: specdown run [OPTIONS] [SPEC_FILES]...
 
 Arguments:
-  [SPEC_FILES]...  The spec files to run
+  [SPEC_FILES]...
+          The spec files to run
 
 Options:
       --workspace-dir <WORKSPACE_DIR>
           Set the workspace directory
+
       --temporary-workspace-dir
           Create a temporary workspace directory
+
       --working-dir <WORKING_DIR>
           The directory where commands will be executed. This is relative to the workspace dir
+
       --workspace-init-command <WORKSPACE_INIT_COMMAND>
           A command to run in the workspace before running the specs
+
       --shell-command <SHELL_COMMAND>
-          The shell command used to execute script blocks [default: "bash -c"]
+          The shell command used to execute script blocks
+          
+          [default: "bash -c"]
+
       --env <ENV>
           Set an environment variable (format: 'VAR_NAME=value')
+
       --unset-env <UNSET_ENV>
           Unset an environment variable
+
       --add-path <ADD_PATH>
           Adds the given directory to PATH
   -j, --jobs <JOBS>
           Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
+
+      --executor <EXECUTOR>
+          The executor to use for running scripts.
+          
+          `shell` (default) runs scripts directly in the host shell. `container` runs scripts inside a Docker container via the Docker Engine socket API. Requires specdown to be built with the `container` feature.
+          
+          [default: shell]
+
+          Possible values:
+          - shell:     Run scripts directly in the host shell (default)
+          - container: Run scripts inside a Docker container via the Docker socket API
+
+      --container-image <CONTAINER_IMAGE>
+          The Docker image to use when `--executor container` is selected.
+          
+          Ignored when the shell executor is used.
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 
 ### Windows Output
@@ -431,28 +457,54 @@ Runs a given Markdown Specification
 Usage: specdown run [OPTIONS] [SPEC_FILES]...
 
 Arguments:
-  [SPEC_FILES]...  The spec files to run
+  [SPEC_FILES]...
+          The spec files to run
 
 Options:
       --workspace-dir <WORKSPACE_DIR>
           Set the workspace directory
+
       --temporary-workspace-dir
           Create a temporary workspace directory
+
       --working-dir <WORKING_DIR>
           The directory where commands will be executed. This is relative to the workspace dir
+
       --workspace-init-command <WORKSPACE_INIT_COMMAND>
           A command to run in the workspace before running the specs
+
       --shell-command <SHELL_COMMAND>
-          The shell command used to execute script blocks [default: "bash -c"]
+          The shell command used to execute script blocks
+          
+          [default: "bash -c"]
+
       --env <ENV>
           Set an environment variable (format: 'VAR_NAME=value')
+
       --unset-env <UNSET_ENV>
           Unset an environment variable
+
       --add-path <ADD_PATH>
           Adds the given directory to PATH
   -j, --jobs <JOBS>
           Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility) [default: 1]
+
+      --executor <EXECUTOR>
+          The executor to use for running scripts.
+          
+          `shell` (default) runs scripts directly in the host shell. `container` runs scripts inside a Docker container via the Docker Engine socket API. Requires specdown to be built with the `container` feature.
+          
+          [default: shell]
+
+          Possible values:
+          - shell:     Run scripts directly in the host shell (default)
+          - container: Run scripts inside a Docker container via the Docker socket API
+
+      --container-image <CONTAINER_IMAGE>
+          The Docker image to use when `--executor container` is selected.
+          
+          Ignored when the shell executor is used.
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -167,7 +167,7 @@ Given `empty_spec.md`:
 Running the following command will fail:
 
 ```shell,script(name="empty_shell_command_example", expected_exit_code=2)
-specdown run --workspace-dir dirname --temporary-workspace-dir empty_shell_command_example.md
+specdown --no-colour run --workspace-dir dirname --temporary-workspace-dir empty_shell_command_example.md
 ```
 
 With the following error message:
@@ -189,7 +189,7 @@ Given `empty_shell_command_example.md`:
 Running the following command will fail:
 
 ```shell,script(name="empty_shell_command_example", expected_exit_code=2)
-specdown run --shell-command '' empty_shell_command_example.md
+specdown --no-colour run --shell-command '' empty_shell_command_example.md
 ```
 
 With the following error message:
@@ -209,7 +209,7 @@ Given `invalid_shell_command_example.md`:
 Running the following command will fail:
 
 ```shell,script(name="invalid_shell_command_example", expected_exit_code=2)
-specdown run --shell-command 'invalid " command' invalid_shell_command_example.md
+specdown --no-colour run --shell-command 'invalid " command' invalid_shell_command_example.md
 ```
 
 With the following error message:
@@ -233,7 +233,7 @@ echo "Hello world"
 Running the following command will fail:
 
 ```shell,script(name="missing_shell_example", expected_exit_code=2)
-specdown run --shell-command 'does-not-exist' missing_shell_example.md
+specdown --no-colour run --shell-command 'does-not-exist' missing_shell_example.md
 ```
 
 With the following error message:

--- a/docs/specs/container_executor.md
+++ b/docs/specs/container_executor.md
@@ -1,0 +1,58 @@
+# Container Executor
+
+Specdown supports running scripts inside a Docker container via the Docker
+Engine socket API, as an alternative to the default shell executor.
+
+## Default Executor
+
+When no `--executor` flag is provided, the shell executor is used.
+
+Given the file `default_executor.md`:
+
+~~~markdown,file(path="default_executor.md")
+# Default Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```
+~~~
+
+```shell,script(name="default_executor")
+specdown run --executor shell default_executor.md
+```
+
+```text,verify(script_name="default_executor")
+Running tests for default_executor.md:
+
+  ✓ running script 'hello' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
+```
+
+## Shell Executor Explicit
+
+You can explicitly select the shell executor.
+
+Given the file `shell_executor.md`:
+
+~~~markdown,file(path="shell_executor.md")
+# Shell Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```
+~~~
+
+```shell,script(name="shell_executor")
+specdown run --executor shell shell_executor.md
+```
+
+```text,verify(script_name="shell_executor")
+Running tests for shell_executor.md:
+
+  ✓ running script 'hello' succeeded
+
+  1 functions run (1 succeeded / 0 failed)
+
+```

--- a/docs/specs/container_executor/default_executor.md
+++ b/docs/specs/container_executor/default_executor.md
@@ -1,0 +1,5 @@
+# Default Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```

--- a/docs/specs/container_executor/shell_executor.md
+++ b/docs/specs/container_executor/shell_executor.md
@@ -1,0 +1,5 @@
+# Shell Executor Test
+
+```shell,script(name="hello")
+echo "hello"
+```

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -28,6 +28,17 @@ pub struct ExecutorConfig {
     /// Ignored when the shell executor is used.
     #[clap(long)]
     pub container_image: Option<String>,
+
+    /// Mount a host directory into the container (repeatable).
+    ///
+    /// Uses Docker CLI bind-mount syntax: `<host_path>:<container_path>[:options]`.
+    /// For example, `--container-volume /host/data:/data` mounts the host
+    /// directory `/host/data` at `/data` inside the container. Append `:ro`
+    /// for a read-only mount.
+    ///
+    /// Only effective with `--executor container`.
+    #[clap(long = "container-volume", value_name = "HOST:CONTAINER[:OPTIONS]")]
+    pub container_volumes: Vec<String>,
 }
 
 #[derive(Args)]

--- a/src/commands/run/arguments.rs
+++ b/src/commands/run/arguments.rs
@@ -1,5 +1,34 @@
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::path::PathBuf;
+
+/// The executor backend to use for running script blocks.
+#[derive(Debug, Clone, Eq, PartialEq, Default, ValueEnum)]
+pub enum ExecutorKind {
+    /// Run scripts directly in the host shell (default).
+    #[default]
+    Shell,
+    /// Run scripts inside a Docker container via the Docker socket API.
+    Container,
+}
+
+/// The executor backend for running spec scripts.
+#[derive(Args, Debug, Clone, Eq, PartialEq, Default)]
+pub struct ExecutorConfig {
+    /// The executor to use for running scripts.
+    ///
+    /// `shell` (default) runs scripts directly in the host shell.
+    /// `container` runs scripts inside a Docker container via the Docker
+    /// Engine socket API. Requires specdown to be built with the
+    /// `container` feature.
+    #[clap(long, default_value = "shell")]
+    pub executor: ExecutorKind,
+
+    /// The Docker image to use when `--executor container` is selected.
+    ///
+    /// Ignored when the shell executor is used.
+    #[clap(long)]
+    pub container_image: Option<String>,
+}
 
 #[derive(Args)]
 pub struct Arguments {
@@ -43,4 +72,8 @@ pub struct Arguments {
     /// Number of parallel jobs to run (0 = all CPUs, default = 1 for backward compatibility)
     #[clap(short = 'j', long = "jobs", default_value_t = 1, allow_hyphen_values = true, value_parser = clap::value_parser!(u32).range(0..))]
     pub jobs: u32,
+
+    /// Executor configuration (shell vs container)
+    #[clap(flatten)]
+    pub executor_config: ExecutorConfig,
 }

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -114,7 +114,12 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
                     .clone()
                     .unwrap_or_else(|| "bash:5".to_string());
                 crate::runner::container_executor::ContainerExecutor::new::<String>(
-                    &image, &shell_cmd, &env, &unset_env, &paths,
+                    &image,
+                    &shell_cmd,
+                    &env,
+                    &unset_env,
+                    &paths,
+                    &args.executor_config.container_volumes,
                 )
                 .map(new_command)
             }

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -92,9 +92,9 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
             .expect("failed to convert working dir into a string"),
     ));
 
-    let new_command = |e| RunCommand {
+    let new_command = |e: Box<dyn crate::runner::Executor>| RunCommand {
         spec_files: args.spec_files.clone(),
-        executor: Box::new(e),
+        executor: e,
         working_dir: actual_working_dir,
         workspace_init_command,
         file_reader,
@@ -102,9 +102,8 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
     };
 
     match args.executor_config.executor {
-        ExecutorKind::Shell => {
-            ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)
-        }
+        ExecutorKind::Shell => ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths)
+            .map(|e| new_command(Box::new(e))),
         ExecutorKind::Container => {
             #[cfg(feature = "container")]
             {
@@ -120,8 +119,9 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
                     &unset_env,
                     &paths,
                     &args.executor_config.container_volumes,
+                    "main",
                 )
-                .map(new_command)
+                .map(|e| new_command(Box::new(e)))
             }
             #[cfg(not(feature = "container"))]
             {

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 pub use arguments::Arguments;
+use arguments::ExecutorKind;
 use file_reader::FileReader;
 use run_command::RunCommand;
 
@@ -100,7 +101,29 @@ fn create_run_command(args: &Arguments) -> Result<RunCommand, Error> {
         jobs,
     };
 
-    ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)
+    match args.executor_config.executor {
+        ExecutorKind::Shell => {
+            ShellExecutor::new(&shell_cmd, &env, &unset_env, &paths).map(new_command)
+        }
+        ExecutorKind::Container => {
+            #[cfg(feature = "container")]
+            {
+                let image = args
+                    .executor_config
+                    .container_image
+                    .clone()
+                    .unwrap_or_else(|| "bash:5".to_string());
+                crate::runner::container_executor::ContainerExecutor::new::<String>(
+                    &image, &shell_cmd, &env, &unset_env, &paths,
+                )
+                .map(new_command)
+            }
+            #[cfg(not(feature = "container"))]
+            {
+                Err(Error::ContainerFeatureNotEnabled)
+            }
+        }
+    }
 }
 
 fn create_workspace(

--- a/src/commands/run/run_command.rs
+++ b/src/commands/run/run_command.rs
@@ -67,7 +67,15 @@ impl RunCommand {
             self.spec_files
                 .par_iter()
                 .map(|spec_file| {
-                    let events = self.run_spec_file(spec_file);
+                    // Clone the executor for each spec file so that
+                    // stateful executors (e.g. ContainerExecutor) get
+                    // their own isolated container/instance. The spec file
+                    // path is passed as a label so the container executor
+                    // can incorporate a file-hash into the container name.
+                    let executor = self
+                        .executor
+                        .clone_box(spec_file.to_str().unwrap_or("unknown"));
+                    let events = self.run_spec_file_with_executor(spec_file, &*executor);
                     // Lock the printer so output from this spec file is printed
                     // atomically and never interleaves with output from another.
                     let mut guard = printer.lock().expect("printer mutex poisoned");
@@ -93,8 +101,21 @@ impl RunCommand {
     }
 
     fn run_spec_file(&self, spec_file: &Path) -> Vec<RunEvent> {
+        self.run_spec_file_with_executor(spec_file, &*self.executor)
+    }
+
+    /// Run a single spec file using the given executor.
+    ///
+    /// This is used by parallel execution to pass a cloned executor
+    /// (via `Executor::clone_box`) so each spec file gets its own
+    /// isolated state (e.g. its own Docker container).
+    fn run_spec_file_with_executor(
+        &self,
+        spec_file: &Path,
+        executor: &dyn Executor,
+    ) -> Vec<RunEvent> {
         let mut state = State::new();
-        let mut runner = Runner::create(&*self.executor, &mut state);
+        let mut runner = Runner::create(executor, &mut state);
 
         let start_events = vec![RunEvent::SpecFileStarted(spec_file.to_path_buf())];
         let contents = self.file_reader.read_file(spec_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ enum Commands {
     Completion(commands::completion::Arguments),
 
     /// Runs a given Markdown Specification
-    Run(commands::run::Arguments),
+    Run(Box<commands::run::Arguments>),
 
     /// Outputs a version of the markdown with all specdown functions removed
     Strip(commands::strip::Arguments),

--- a/src/parsers/actions.rs
+++ b/src/parsers/actions.rs
@@ -2,8 +2,9 @@ use crate::parsers::code_block_type::{
     BackgroundCodeBlock, CodeBlockType, ScriptCodeBlock, VerifyCodeBlock,
 };
 use crate::types::{
-    Action, BackgroundAction, CreateFileAction, FileContent, ScriptAction, ScriptCode, TargetOs,
-    VerifyAction, VerifyValue,
+    Action, BackgroundAction, CreateFileAction, FileContent, ResponseAction, ResponseBody,
+    ResponseCodeBlock, ResponseHeader, ScriptAction, ScriptCode, TargetOs, VerifyAction,
+    VerifyValue,
 };
 use std::env::consts::OS;
 
@@ -22,6 +23,10 @@ pub fn create_action(code_block_type: &CodeBlockType, literal: String) -> Option
         CodeBlockType::Background(background_code_block) => Some(Action::Background(
             to_background_action(background_code_block, literal),
         )),
+        CodeBlockType::Response(response_code_block) => Some(Action::Response(to_response_action(
+            response_code_block,
+            literal,
+        ))),
         CodeBlockType::Skip() => None,
     }
 }
@@ -48,6 +53,62 @@ fn to_background_action(code_block: &BackgroundCodeBlock, literal: String) -> Ba
         script_name: script_name.clone(),
         script_code: ScriptCode(literal),
     }
+}
+
+fn to_response_action(code_block: &ResponseCodeBlock, literal: String) -> ResponseAction {
+    let ResponseCodeBlock {
+        name,
+        status,
+        headers,
+        content_type,
+        delay,
+        body: _,
+    } = code_block;
+
+    let mut decoded_headers = headers
+        .as_deref()
+        .map(decode_response_headers)
+        .unwrap_or_default();
+
+    if let Some(ct) = content_type {
+        let has_content_type = decoded_headers.iter().any(|h| h.name == "content-type");
+        if !has_content_type {
+            decoded_headers.push(ResponseHeader {
+                name: "content-type".to_string(),
+                value: ct.clone(),
+            });
+        }
+    }
+
+    let body = if literal.is_empty() {
+        ResponseBody::Empty
+    } else {
+        ResponseBody::Literal(literal)
+    };
+    // Note: ResponseBody::Inline is reserved for a future body="..." argument.
+    // It is not produced by the v1 parser but the variant exists for forward compat.
+
+    ResponseAction {
+        name: name.clone(),
+        status: *status,
+        headers: decoded_headers,
+        delay: *delay,
+        body,
+    }
+}
+
+fn decode_response_headers(raw: &str) -> Vec<ResponseHeader> {
+    raw.split(';')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .filter_map(|entry| {
+            let (name, value) = entry.split_once(':')?;
+            Some(ResponseHeader {
+                name: name.trim().to_lowercase(),
+                value: value.trim().to_string(),
+            })
+        })
+        .collect()
 }
 
 fn to_verify_action(
@@ -88,8 +149,8 @@ mod tests {
     use crate::parsers::code_block_type::VerifyCodeBlock;
     use crate::types::BackgroundAction;
     use crate::types::{
-        CreateFileAction, FilePath, OutputExpectation, ScriptAction, ScriptName, Source, Stream,
-        TargetOs, VerifyAction,
+        CreateFileAction, FilePath, MockName, OutputExpectation, ResponseAction, ResponseBody,
+        ResponseHeader, ScriptAction, ScriptName, Source, Stream, TargetOs, VerifyAction,
     };
 
     #[test]
@@ -224,6 +285,122 @@ mod tests {
         assert_eq!(
             create_action(&CodeBlockType::Skip(), "content".to_string()),
             None
+        );
+    }
+
+    #[test]
+    fn create_action_for_response_with_defaults() {
+        use crate::types::{DelayMillis, ResponseCodeBlock, StatusCode};
+
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Response(ResponseCodeBlock {
+                    name: MockName("my-mock".to_string()),
+                    status: StatusCode(200),
+                    headers: None,
+                    content_type: None,
+                    delay: DelayMillis(0),
+                    body: ResponseBody::Empty,
+                }),
+                "{\"hello\": \"world\"}".to_string(),
+            ),
+            Some(Action::Response(ResponseAction {
+                name: MockName("my-mock".to_string()),
+                status: StatusCode(200),
+                headers: vec![],
+                delay: DelayMillis(0),
+                body: ResponseBody::Literal("{\"hello\": \"world\"}".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_response_with_empty_literal() {
+        use crate::types::{DelayMillis, ResponseCodeBlock, StatusCode};
+
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Response(ResponseCodeBlock {
+                    name: MockName("no-body".to_string()),
+                    status: StatusCode(204),
+                    headers: None,
+                    content_type: None,
+                    delay: DelayMillis(0),
+                    body: ResponseBody::Empty,
+                }),
+                String::new(),
+            ),
+            Some(Action::Response(ResponseAction {
+                name: MockName("no-body".to_string()),
+                status: StatusCode(204),
+                headers: vec![],
+                delay: DelayMillis(0),
+                body: ResponseBody::Empty,
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_response_with_content_type() {
+        use crate::types::{DelayMillis, ResponseCodeBlock, StatusCode};
+
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Response(ResponseCodeBlock {
+                    name: MockName("json-mock".to_string()),
+                    status: StatusCode(200),
+                    headers: None,
+                    content_type: Some("application/json".to_string()),
+                    delay: DelayMillis(0),
+                    body: ResponseBody::Empty,
+                }),
+                "{}".to_string(),
+            ),
+            Some(Action::Response(ResponseAction {
+                name: MockName("json-mock".to_string()),
+                status: StatusCode(200),
+                headers: vec![ResponseHeader {
+                    name: "content-type".to_string(),
+                    value: "application/json".to_string(),
+                }],
+                delay: DelayMillis(0),
+                body: ResponseBody::Literal("{}".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_response_with_explicit_headers() {
+        use crate::types::{DelayMillis, ResponseCodeBlock, StatusCode};
+
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Response(ResponseCodeBlock {
+                    name: MockName("hdr-mock".to_string()),
+                    status: StatusCode(200),
+                    headers: Some("X-Custom:value; Content-Type:text/plain".to_string()),
+                    content_type: Some("application/json".to_string()),
+                    delay: DelayMillis(100),
+                    body: ResponseBody::Empty,
+                }),
+                "hello".to_string(),
+            ),
+            Some(Action::Response(ResponseAction {
+                name: MockName("hdr-mock".to_string()),
+                status: StatusCode(200),
+                headers: vec![
+                    ResponseHeader {
+                        name: "x-custom".to_string(),
+                        value: "value".to_string(),
+                    },
+                    ResponseHeader {
+                        name: "content-type".to_string(),
+                        value: "text/plain".to_string(),
+                    },
+                ],
+                delay: DelayMillis(100),
+                body: ResponseBody::Literal("hello".to_string()),
+            }))
         );
     }
 }

--- a/src/parsers/code_block_type.rs
+++ b/src/parsers/code_block_type.rs
@@ -1,7 +1,10 @@
 use crate::parsers::error::{Error, Result};
 use crate::parsers::function_string_parser;
 use crate::parsers::function_string_parser::Function;
-use crate::types::{ExitCode, FilePath, OutputExpectation, ScriptName, Source, Stream, TargetOs};
+use crate::types::{
+    DelayMillis, ExitCode, FilePath, MockName, OutputExpectation, ResponseBody, ResponseCodeBlock,
+    ScriptName, Source, StatusCode, Stream, TargetOs,
+};
 use nom::combinator::map_res;
 use nom::{IResult, Parser};
 
@@ -29,6 +32,7 @@ pub enum CodeBlockType {
     Verify(VerifyCodeBlock),
     CreateFile(FilePath),
     Background(BackgroundCodeBlock),
+    Response(ResponseCodeBlock),
     Skip(),
 }
 
@@ -42,6 +46,7 @@ fn from_function(f: Function) -> Result<CodeBlockType> {
         "verify" => verify_to_code_block_type(&f),
         "file" => file_to_code_block_type(&f),
         "background" => background_to_code_block_type(&f),
+        "response" => response_to_code_block_type(&f),
         "skip" => Ok(skip_to_code_block_type(&f)),
         _ => Err(Error::UnknownFunction(f.name)),
     }
@@ -97,6 +102,61 @@ fn background_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
     };
     Ok(CodeBlockType::Background(BackgroundCodeBlock {
         script_name: name,
+    }))
+}
+
+fn response_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
+    let name = MockName(f.get_string_argument("name")?);
+
+    let status = if f.has_argument("status") {
+        let raw = f.get_integer_argument("status")?;
+        StatusCode::parse(raw).map_err(|_| Error::InvalidArgumentValue {
+            function: "response".to_string(),
+            argument: "status".to_string(),
+            expected: "an HTTP status code between 100 and 599".to_string(),
+            got: raw.to_string(),
+        })?
+    } else {
+        StatusCode::default()
+    };
+
+    let headers = if f.has_argument("headers") {
+        Some(f.get_string_argument("headers")?)
+    } else {
+        None
+    };
+
+    let content_type = if f.has_argument("content_type") {
+        Some(f.get_string_argument("content_type")?)
+    } else {
+        None
+    };
+
+    let delay = if f.has_argument("delay") {
+        let raw = f.get_integer_argument("delay")?;
+        DelayMillis::parse(raw).map_err(|_| Error::InvalidArgumentValue {
+            function: "response".to_string(),
+            argument: "delay".to_string(),
+            expected: "a delay in milliseconds between 0 and 300000".to_string(),
+            got: raw.to_string(),
+        })?
+    } else {
+        DelayMillis::default()
+    };
+
+    let body = if f.has_argument("body") {
+        ResponseBody::Inline(f.get_string_argument("body")?)
+    } else {
+        ResponseBody::Empty
+    };
+
+    Ok(CodeBlockType::Response(ResponseCodeBlock {
+        name,
+        status,
+        headers,
+        content_type,
+        delay,
+        body,
     }))
 }
 

--- a/src/results/action_result.rs
+++ b/src/results/action_result.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    BackgroundAction, CreateFileAction, ExitCode, OutputExpectation, ScriptAction, ScriptName,
-    VerifyAction,
+    BackgroundAction, CreateFileAction, ExitCode, MockName, OutputExpectation, ScriptAction,
+    ScriptName, VerifyAction,
 };
 
 #[derive(Debug, Eq, PartialEq)]
@@ -9,6 +9,7 @@ pub enum ActionError {
     UnexpectedOutputIsPresent(ScriptResult),
     OutputDoesNotMatch(VerifyResult),
     BackgroundExitedWithError(BackgroundStopResult),
+    UnpairedResponse(MockName),
 }
 
 trait ActionErrorProvider {
@@ -118,6 +119,31 @@ pub enum BackgroundExitStatus {
     Exited(ExitCode),
 }
 
+/// Whether a response block was successfully paired with a request block.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum ResponseStatus {
+    /// The response was paired with a matching request block.
+    #[default]
+    Paired,
+    /// No matching request block was found for this response.
+    Unpaired,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResponseResult {
+    pub name: MockName,
+    pub status: ResponseStatus,
+}
+
+impl ActionErrorProvider for ResponseResult {
+    fn error(&self) -> Option<ActionError> {
+        match self.status {
+            ResponseStatus::Paired => None,
+            ResponseStatus::Unpaired => Some(ActionError::UnpairedResponse(self.name.clone())),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ActionResult {
     Script(ScriptResult),
@@ -125,6 +151,7 @@ pub enum ActionResult {
     CreateFile(CreateFileResult),
     BackgroundStart(BackgroundStartResult),
     BackgroundStop(BackgroundStopResult),
+    Response(ResponseResult),
 }
 
 impl ActionResult {
@@ -143,6 +170,7 @@ impl ActionResult {
             Self::CreateFile(result) => result,
             Self::BackgroundStart(result) => result,
             Self::BackgroundStop(result) => result,
+            Self::Response(result) => result,
         }
     }
 }
@@ -413,6 +441,39 @@ mod tests {
                 assert_eq!(
                     result.error(),
                     Some(ActionError::BackgroundExitedWithError(stop_result))
+                );
+                assert!(!result.success());
+            }
+        }
+
+        mod response {
+            use crate::results::action_result::{
+                ActionError, ActionResult, ResponseResult, ResponseStatus,
+            };
+            use crate::types::MockName;
+
+            #[test]
+            fn returns_none_when_paired() {
+                let result = ActionResult::Response(ResponseResult {
+                    name: MockName("my-mock".to_string()),
+                    status: ResponseStatus::Paired,
+                });
+                assert_eq!(result.error(), None);
+                assert!(result.success());
+            }
+
+            #[test]
+            fn returns_unpaired_response_error_when_unpaired() {
+                let response_result = ResponseResult {
+                    name: MockName("orphan".to_string()),
+                    status: ResponseStatus::Unpaired,
+                };
+                let result = ActionResult::Response(response_result.clone());
+                assert_eq!(
+                    result.error(),
+                    Some(ActionError::UnpairedResponse(MockName(
+                        "orphan".to_string()
+                    )))
                 );
                 assert!(!result.success());
             }

--- a/src/results/basic_printer.rs
+++ b/src/results/basic_printer.rs
@@ -11,7 +11,7 @@ use crate::types::{ExitCode, OutputExpectation, Stream, VerifyAction};
 use super::action_result::ActionResult;
 use super::action_result::{
     ActionError, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
-    CreateFileResult, ScriptResult, VerifyResult,
+    CreateFileResult, ResponseResult, ScriptResult, VerifyResult,
 };
 use super::printer::Printer;
 
@@ -134,6 +134,9 @@ impl BasicPrinter {
                         .map_or("<unnamed>".to_string(), Into::into)
                 )
             }
+            ActionResult::Response(ResponseResult { name, .. }) => {
+                format!("setting response for mock '{name}'")
+            }
         }
     }
 
@@ -172,6 +175,9 @@ impl BasicPrinter {
                 }
                 BackgroundExitStatus::Killed => "succeeded".to_string(),
             },
+            Some(ActionError::UnpairedResponse(_)) => {
+                "failed (no matching request block)".to_string()
+            }
             None => "succeeded".to_string(),
         }
     }
@@ -195,7 +201,7 @@ impl BasicPrinter {
             }) => {
                 self.display_diff(&String::from(expected_value.clone()), got);
             }
-            ActionError::BackgroundExitedWithError(_) => {}
+            ActionError::BackgroundExitedWithError(_) | ActionError::UnpairedResponse(_) => {}
         }
     }
 
@@ -818,6 +824,43 @@ mod tests {
             output.contains("all good"),
             "display_success_item should contain the text, got: {:?}",
             output
+        );
+    }
+
+    #[test]
+    fn action_title_formats_response_with_mock_name() {
+        use crate::results::action_result::{ResponseResult, ResponseStatus};
+        use crate::types::MockName;
+        let result = ActionResult::Response(ResponseResult {
+            name: MockName("list-users".to_string()),
+            status: ResponseStatus::Paired,
+        });
+        let title = BasicPrinter::action_title(&result);
+        assert!(
+            title.contains("list-users"),
+            "action_title for response should contain the mock name, got: {:?}",
+            title
+        );
+        assert!(
+            title.contains("response"),
+            "action_title for response should contain 'response', got: {:?}",
+            title
+        );
+    }
+
+    #[test]
+    fn action_result_message_shows_failure_for_unpaired_response() {
+        use crate::results::action_result::{ResponseResult, ResponseStatus};
+        use crate::types::MockName;
+        let result = ActionResult::Response(ResponseResult {
+            name: MockName("orphan".to_string()),
+            status: ResponseStatus::Unpaired,
+        });
+        let msg = BasicPrinter::action_result_message(&result);
+        assert!(
+            msg.contains("no matching request block"),
+            "action_result_message for unpaired response should mention 'no matching request block', got: {:?}",
+            msg
         );
     }
 }

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,6 +1,6 @@
 pub use action_result::{
     ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
-    CreateFileResult, ScriptResult, VerifyResult,
+    CreateFileResult, ResponseResult, ResponseStatus, ScriptResult, VerifyResult,
 };
 pub use printer::Printer;
 

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,16 +1,15 @@
-use std::process::Child;
-
 use crate::results::{
     ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
 };
 use crate::types::BackgroundAction;
 use crate::types::ExitCode;
 
+use super::background_handle::BackgroundHandle;
 use super::executor::Executor;
 use super::Error;
 
 pub struct BackgroundProcess {
-    pub child: Child,
+    pub handle: Box<dyn BackgroundHandle>,
     pub script_name: Option<crate::types::ScriptName>,
 }
 
@@ -23,7 +22,7 @@ pub fn start(
         script_code,
     } = action;
 
-    let child = executor.spawn(script_code)?;
+    let handle = executor.spawn(script_code)?;
 
     let result = ActionResult::BackgroundStart(BackgroundStartResult {
         action: action.clone(),
@@ -32,7 +31,7 @@ pub fn start(
     Ok((
         result,
         BackgroundProcess {
-            child,
+            handle,
             script_name: script_name.clone(),
         },
     ))
@@ -40,32 +39,19 @@ pub fn start(
 
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     // Check if the process has already exited on its own.
-    match bg.child.try_wait() {
-        Ok(Some(status)) => {
-            // The process exited before we could kill it.
-            let exit_code = status.code().unwrap_or(-1);
-            ActionResult::BackgroundStop(BackgroundStopResult {
-                script_name: bg.script_name,
-                exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
-            })
-        }
-        Ok(None) => {
-            // The process is still running — kill it and wait for it to exit.
-            let _ = bg.child.kill();
-            let _ = bg.child.wait();
-            ActionResult::BackgroundStop(BackgroundStopResult {
-                script_name: bg.script_name,
-                exit_status: BackgroundExitStatus::Killed,
-            })
-        }
-        Err(_) => {
-            // Could not determine the process status — kill it as a fallback.
-            let _ = bg.child.kill();
-            let _ = bg.child.wait();
-            ActionResult::BackgroundStop(BackgroundStopResult {
-                script_name: bg.script_name,
-                exit_status: BackgroundExitStatus::Killed,
-            })
-        }
+    if let Some(exit_code) = bg.handle.try_wait() {
+        // The process exited before we could kill it.
+        ActionResult::BackgroundStop(BackgroundStopResult {
+            script_name: bg.script_name,
+            exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
+        })
+    } else {
+        // The process is still running — kill it and wait for it to exit.
+        bg.handle.kill();
+        let _ = bg.handle.wait();
+        ActionResult::BackgroundStop(BackgroundStopResult {
+            script_name: bg.script_name,
+            exit_status: BackgroundExitStatus::Killed,
+        })
     }
 }

--- a/src/runner/background_handle.rs
+++ b/src/runner/background_handle.rs
@@ -1,0 +1,51 @@
+//! Trait abstracting a background process that can be killed and waited on.
+//!
+//! This allows the [`Executor`](super::executor::Executor) trait's `spawn`
+//! method to return a type-erased handle rather than being hard-wired to
+//! `std::process::Child`, enabling non-process-based executors (such as the
+//! container executor) to support background scripts.
+
+use std::fmt::Debug;
+
+/// A handle to a background process that can be stopped and waited on.
+///
+/// Implementations include:
+/// - [`ShellBackgroundHandle`](crate::runner::shell_executor::ShellBackgroundHandle)
+///   wrapping `std::process::Child`
+/// - [`ContainerBackgroundHandle`](crate::runner::container_executor::ContainerBackgroundHandle)
+///   wrapping a Docker container managed via the socket API
+///   (only available with the `container` feature)
+pub trait BackgroundHandle: Debug + Send {
+    /// Signal the process to terminate (SIGTERM equivalent).
+    fn kill(&mut self);
+
+    /// Wait for the process to exit and return its exit code.
+    ///
+    /// Returns `None` if the process was killed by a signal and no exit code
+    /// is available.
+    fn wait(&mut self) -> Option<i32>;
+
+    /// Check if the process has already exited without blocking.
+    ///
+    /// Returns `Some(exit_code)` if the process has exited, or `None` if it
+    /// is still running.
+    fn try_wait(&mut self) -> Option<i32>;
+}
+
+impl BackgroundHandle for std::process::Child {
+    fn kill(&mut self) {
+        let _ = std::process::Child::kill(self);
+    }
+
+    fn wait(&mut self) -> Option<i32> {
+        std::process::Child::wait(self)
+            .ok()
+            .and_then(|status| status.code())
+    }
+
+    fn try_wait(&mut self) -> Option<i32> {
+        std::process::Child::try_wait(self)
+            .ok()
+            .and_then(|status| status?.code())
+    }
+}

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -4,29 +4,44 @@
 //! This executor connects directly to the Docker socket
 //! (`/var/run/docker.sock` on Linux) and manages containers through the
 //! API — it does NOT shell out to `docker run`.
+//!
+//! ## Persistence
+//!
+//! A single container is created when the executor is first used and kept
+//! alive for the lifetime of the executor. All `script` and `background`
+//! blocks reuse this container via the Docker **exec** API, so filesystem
+//! state (files, environment, etc.) persists across script blocks within
+//! a spec file run.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use bollard::container::{
-    AttachContainerOptions, AttachContainerResults, Config, CreateContainerOptions, LogOutput,
-    RemoveContainerOptions,
+    Config, CreateContainerOptions, LogOutput, RemoveContainerOptions, StartContainerOptions,
 };
+use bollard::exec::{CreateExecOptions, StartExecOptions};
+use bollard::models::HostConfig;
 use bollard::Docker;
+use futures_util::StreamExt;
 
 use crate::types::ScriptCode;
 
 use super::background_handle::BackgroundHandle;
 use super::executor::Output;
 use super::{Error, Executor};
-use futures_util::StreamExt;
 use std::convert::TryFrom;
+
+/// Monotonically increasing counter for unique background PID-file names.
+static BG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// An executor that runs scripts inside a Docker container, communicating
 /// with the Docker daemon over its socket API.
 ///
 /// Created with [`ContainerExecutor::new`], which establishes a connection
-/// to the Docker daemon.
+/// to the Docker daemon. A persistent container is created lazily on the
+/// first `execute` or `spawn` call and reused for all subsequent calls.
+/// The container is removed when the executor is dropped.
 #[derive(Debug)]
 pub struct ContainerExecutor {
     image: String,
@@ -34,8 +49,12 @@ pub struct ContainerExecutor {
     env: HashMap<String, String>,
     unset_env: Vec<String>,
     paths: Vec<PathBuf>,
+    binds: Vec<String>,
+    working_dir: String,
     runtime: tokio::runtime::Runtime,
     docker: Docker,
+    /// ID of the persistent container, created on first use.
+    container_id: std::cell::RefCell<Option<String>>,
 }
 
 impl ContainerExecutor {
@@ -49,6 +68,8 @@ impl ContainerExecutor {
     /// * `env` - Environment variables to set, as `(KEY, VALUE)` pairs.
     /// * `unset_env` - Environment variables to unset.
     /// * `paths` - Additional paths to prepend to `PATH`.
+    /// * `binds` - Docker bind-mount specifications (e.g.
+    ///   `"/host/path:/container/path"` or `"/host:/container:ro"`).
     ///
     /// # Errors
     ///
@@ -60,6 +81,7 @@ impl ContainerExecutor {
         env: &[(String, String)],
         unset_env: &[String],
         paths: &[P],
+        binds: &[String],
     ) -> Result<Self, Error>
     where
         P: AsRef<std::ffi::OsStr>,
@@ -96,8 +118,11 @@ impl ContainerExecutor {
             env: env.iter().cloned().collect(),
             unset_env: unset_env.to_vec(),
             paths: paths.iter().map(PathBuf::from).collect(),
+            binds: binds.to_vec(),
+            working_dir: "/workspace".to_string(),
             runtime,
             docker,
+            container_id: std::cell::RefCell::new(None),
         })
     }
 
@@ -129,142 +154,151 @@ impl ContainerExecutor {
         result
     }
 
-    /// Build the container command from the shell command string.
+    /// Build the command vector for a Docker exec from the shell command
+    /// string and the script code.
     ///
-    /// Splits the shell command (e.g. `"bash -c"`) into entrypoint + cmd
-    /// parts, then appends the script code as the final argument.
-    fn container_command(&self, code: &str) -> (Vec<String>, Vec<String>) {
-        let words = shell_words::split(&self.shell_command).unwrap_or_default();
+    /// Splits the shell command (e.g. `"bash -c"`) into individual words,
+    /// then appends the script code as the final argument.
+    fn exec_command(&self, code: &str) -> Vec<String> {
+        let mut words = shell_words::split(&self.shell_command).unwrap_or_default();
         if words.is_empty() {
-            return (
-                vec!["bash".to_string()],
-                vec!["-c".to_string(), code.to_string()],
-            );
+            words = vec!["bash".to_string(), "-c".to_string()];
         }
-
-        let (entrypoint, cmd) = words.split_at(1);
-        let mut cmd = cmd.to_vec();
-        cmd.push(code.to_string());
-
-        (entrypoint.to_vec(), cmd)
+        words.push(code.to_string());
+        words
     }
 
-    /// Build a `Config` for the Docker container.
-    fn container_config(&self, code: &str) -> Config<String> {
-        let (entrypoint, cmd) = self.container_command(code);
-        let env = self.container_env();
-
-        Config {
-            image: Some(self.image.clone()),
-            entrypoint: Some(entrypoint),
-            cmd: Some(cmd),
-            env: Some(env),
-            attach_stdout: Some(true),
-            attach_stderr: Some(true),
-            open_stdin: Some(false),
-            stdin_once: Some(false),
-            tty: Some(false),
-            ..Default::default()
+    /// Return the ID of the persistent container, creating and starting it
+    /// if it does not yet exist.
+    ///
+    /// The container runs `sleep infinity` so it stays alive between exec
+    /// calls, providing filesystem and environment persistence across all
+    /// script and background blocks in a spec file.
+    fn ensure_container(&self) -> Result<String, Error> {
+        // Fast path: container already created.
+        if let Some(id) = self.container_id.borrow().clone() {
+            return Ok(id);
         }
+
+        let docker = self.docker.clone();
+        let image = self.image.clone();
+        let env = self.container_env();
+        let working_dir = self.working_dir.clone();
+        let binds = self.binds.clone();
+
+        let container_id = self.runtime.block_on(async move {
+            let config = Config {
+                image: Some(image),
+                entrypoint: Some(vec!["sleep".to_string()]),
+                cmd: Some(vec!["infinity".to_string()]),
+                env: Some(env),
+                working_dir: Some(working_dir),
+                open_stdin: Some(false),
+                stdin_once: Some(false),
+                tty: Some(false),
+                host_config: Some(HostConfig {
+                    binds: if binds.is_empty() { None } else { Some(binds) },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let create_result = docker
+                .create_container(None::<CreateContainerOptions<String>>, config)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to create persistent container: {err}"),
+                })?;
+
+            docker
+                .start_container(&create_result.id, None::<StartContainerOptions<String>>)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start persistent container: {err}"),
+                })?;
+
+            Ok::<String, Error>(create_result.id)
+        })?;
+
+        *self.container_id.borrow_mut() = Some(container_id.clone());
+        Ok(container_id)
     }
 }
 
 impl Executor for ContainerExecutor {
     fn execute(&self, script: &ScriptCode) -> Result<Output, Error> {
         let ScriptCode(code_string) = script;
-
-        let config = self.container_config(code_string);
+        let container_id = self.ensure_container()?;
 
         let docker = self.docker.clone();
+        let cmd = self.exec_command(code_string);
+        let env = self.container_env();
+        let working_dir = self.working_dir.clone();
 
         self.runtime.block_on(async move {
-            // Create the container
-            let create_result = docker
-                .create_container(None::<CreateContainerOptions<String>>, config)
-                .await
-                .map_err(|err| Error::SpawnFailed {
-                    message: format!("Failed to create container: {err}"),
-                })?;
-
-            let container_id = create_result.id;
-
-            // Attach to the container to capture stdout/stderr
-            let attach_options = Some(AttachContainerOptions::<String> {
-                stdin: Some(false),
-                stdout: Some(true),
-                stderr: Some(true),
-                stream: Some(true),
-                logs: Some(false),
-                detach_keys: None,
-            });
-
-            let AttachContainerResults { output, .. } = docker
-                .attach_container(&container_id, attach_options)
-                .await
-                .map_err(|err| Error::SpawnFailed {
-                    message: format!("Failed to attach to container: {err}"),
-                })?;
-
-            // Start the container
-            docker
-                .start_container(
+            // Create an exec instance in the persistent container
+            let exec = docker
+                .create_exec(
                     &container_id,
-                    None::<bollard::container::StartContainerOptions<String>>,
+                    CreateExecOptions {
+                        cmd: Some(cmd),
+                        env: Some(env),
+                        working_dir: Some(working_dir),
+                        attach_stdout: Some(true),
+                        attach_stderr: Some(true),
+                        attach_stdin: Some(false),
+                        ..Default::default()
+                    },
                 )
                 .await
                 .map_err(|err| Error::SpawnFailed {
-                    message: format!("Failed to start container: {err}"),
+                    message: format!("Failed to create exec: {err}"),
                 })?;
 
-            // Collect stdout and stderr from the attach stream
+            // Start the exec (attached) and capture output
+            let start_result = docker
+                .start_exec(&exec.id, None::<StartExecOptions>)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start exec: {err}"),
+                })?;
+
             let mut stdout = String::new();
             let mut stderr = String::new();
 
-            let mut output = output;
-            while let Some(msg) = output.next().await {
-                match msg {
-                    Ok(LogOutput::StdOut { message }) => {
-                        stdout.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(LogOutput::StdErr { message }) => {
-                        stderr.push_str(&String::from_utf8_lossy(&message));
-                    }
-                    Ok(_) => {}
-                    Err(err) => {
-                        stderr.push_str("Error reading container output: ");
-                        stderr.push_str(&err.to_string());
-                        stderr.push('\n');
+            if let bollard::exec::StartExecResults::Attached {
+                output: mut output_stream,
+                ..
+            } = start_result
+            {
+                while let Some(msg) = output_stream.next().await {
+                    match msg {
+                        Ok(LogOutput::StdOut { message }) => {
+                            stdout.push_str(&String::from_utf8_lossy(&message));
+                        }
+                        Ok(LogOutput::StdErr { message }) => {
+                            stderr.push_str(&String::from_utf8_lossy(&message));
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            stderr.push_str("Error reading exec output: ");
+                            stderr.push_str(&err.to_string());
+                            stderr.push('\n');
+                        }
                     }
                 }
             }
 
-            // Wait for the container to exit and get the exit code
-            let wait_stream = docker.wait_container(
-                &container_id,
-                None::<bollard::container::WaitContainerOptions<String>>,
-            );
-            let exit_code = {
-                futures_util::pin_mut!(wait_stream);
-                let mut code = None;
-                while let Some(msg) = wait_stream.next().await {
-                    if let Ok(response) = msg {
-                        code = Some(i32::try_from(response.status_code).unwrap_or(0));
-                        break;
-                    }
-                }
-                code
-            };
+            // Get the exit code
+            let inspect =
+                docker
+                    .inspect_exec(&exec.id)
+                    .await
+                    .map_err(|err| Error::SpawnFailed {
+                        message: format!("Failed to inspect exec: {err}"),
+                    })?;
 
-            // Remove the container (force, in case it's still running)
-            let _ = docker
-                .remove_container(
-                    &container_id,
-                    Some(RemoveContainerOptions {
-                        force: true,
-                        ..Default::default()
-                    }),
-                )
-                .await;
+            let exit_code = inspect.exit_code.map(|c| i32::try_from(c).unwrap_or(0));
 
             Ok(Output {
                 stdout,
@@ -276,51 +310,99 @@ impl Executor for ContainerExecutor {
 
     fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
         let ScriptCode(code_string) = script;
-
-        let config = self.container_config(code_string);
+        let container_id = self.ensure_container()?;
+        let container_id_for_handle = container_id.clone();
 
         let docker = self.docker.clone();
+        let env = self.container_env();
+        let working_dir = self.working_dir.clone();
 
-        self.runtime.block_on(async move {
-            // Create the container
-            let create_result = docker
-                .create_container(None::<CreateContainerOptions<String>>, config)
-                .await
-                .map_err(|err| Error::SpawnFailed {
-                    message: format!("Failed to create container: {err}"),
-                })?;
+        // Wrap the script so it records its PID inside the container.
+        // This lets us kill the background process later via another exec.
+        let bg_num = BG_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid_file = format!("/tmp/.specdown_bg_{bg_num}");
+        let wrapped_code = format!("echo $$ > {pid_file}; exec {code_string}");
+        let cmd = self.exec_command(&wrapped_code);
 
-            let container_id = create_result.id;
-
-            // Start the container
-            docker
-                .start_container(
+        let exec_id = self.runtime.block_on(async move {
+            let exec = docker
+                .create_exec(
                     &container_id,
-                    None::<bollard::container::StartContainerOptions<String>>,
+                    CreateExecOptions {
+                        cmd: Some(cmd),
+                        env: Some(env),
+                        working_dir: Some(working_dir),
+                        ..Default::default()
+                    },
                 )
                 .await
                 .map_err(|err| Error::SpawnFailed {
-                    message: format!("Failed to start container: {err}"),
+                    message: format!("Failed to create background exec: {err}"),
                 })?;
 
-            Ok(Box::new(ContainerBackgroundHandle {
-                container_id,
-                docker,
-                runtime: tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|err| Error::SpawnFailed {
-                        message: format!("Failed to create runtime for background handle: {err}"),
-                    })?,
-            }) as Box<dyn BackgroundHandle>)
-        })
+            // Start detached so it runs in the background
+            docker
+                .start_exec(
+                    &exec.id,
+                    Some(StartExecOptions {
+                        detach: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start background exec: {err}"),
+                })?;
+
+            Ok::<String, Error>(exec.id)
+        })?;
+
+        let handle_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| Error::SpawnFailed {
+                message: format!("Failed to create runtime for background handle: {err}"),
+            })?;
+
+        Ok(Box::new(ContainerBackgroundHandle {
+            container_id: container_id_for_handle,
+            exec_id,
+            pid_file,
+            docker: self.docker.clone(),
+            runtime: handle_runtime,
+        }) as Box<dyn BackgroundHandle>)
     }
 }
 
-/// A handle to a background Docker container that can be killed and waited on.
+impl Drop for ContainerExecutor {
+    fn drop(&mut self) {
+        let docker = self.docker.clone();
+        if let Some(container_id) = self.container_id.borrow().clone() {
+            let _ = self.runtime.block_on(async move {
+                docker
+                    .remove_container(
+                        &container_id,
+                        Some(RemoveContainerOptions {
+                            force: true,
+                            ..Default::default()
+                        }),
+                    )
+                    .await
+            });
+        }
+    }
+}
+
+/// A handle to a background process running inside the persistent
+/// container via Docker exec.
+///
+/// The process is tracked by its exec ID. To kill it, we read the PID
+/// (recorded at spawn time) and send `SIGTERM` from another exec.
 #[derive(Debug)]
 pub struct ContainerBackgroundHandle {
     container_id: String,
+    exec_id: String,
+    pid_file: String,
     docker: Docker,
     runtime: tokio::runtime::Runtime,
 }
@@ -328,48 +410,62 @@ pub struct ContainerBackgroundHandle {
 impl BackgroundHandle for ContainerBackgroundHandle {
     fn kill(&mut self) {
         let container_id = self.container_id.clone();
+        let pid_file = self.pid_file.clone();
         let docker = self.docker.clone();
         let _ = self.runtime.block_on(async move {
-            docker
-                .kill_container(
+            // Kill the background process using its recorded PID, then
+            // clean up the PID file.
+            let kill_cmd = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("kill -TERM $(cat {pid_file}) 2>/dev/null; rm -f {pid_file}"),
+            ];
+            let exec = docker
+                .create_exec(
                     &container_id,
-                    None::<bollard::container::KillContainerOptions<String>>,
+                    CreateExecOptions::<String> {
+                        cmd: Some(kill_cmd),
+                        ..Default::default()
+                    },
                 )
                 .await
+                .ok()?;
+            docker
+                .start_exec(&exec.id, None::<StartExecOptions>)
+                .await
+                .ok()?;
+            Some(())
         });
     }
 
     fn wait(&mut self) -> Option<i32> {
-        let container_id = self.container_id.clone();
+        let exec_id = self.exec_id.clone();
         let docker = self.docker.clone();
         self.runtime.block_on(async move {
-            use futures_util::StreamExt;
-            let mut stream = docker.wait_container(
-                &container_id,
-                None::<bollard::container::WaitContainerOptions<String>>,
-            );
-            stream
-                .next()
-                .await
-                .and_then(std::result::Result::ok)
-                .map(|r| i32::try_from(r.status_code).unwrap_or(0))
+            loop {
+                match docker.inspect_exec(&exec_id).await {
+                    Ok(info) => {
+                        if info.running != Some(true) {
+                            return info.exit_code.map(|c| i32::try_from(c).unwrap_or(0));
+                        }
+                    }
+                    Err(_) => return None,
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
         })
-        // Container may have already been removed; return None
     }
 
     fn try_wait(&mut self) -> Option<i32> {
-        let container_id = self.container_id.clone();
+        let exec_id = self.exec_id.clone();
         let docker = self.docker.clone();
         self.runtime.block_on(async move {
-            // Inspect the container to check if it has exited
-            match docker.inspect_container(&container_id, None).await {
+            match docker.inspect_exec(&exec_id).await {
                 Ok(info) => {
-                    let state = info.state?;
-                    match state.status {
-                        Some(bollard::models::ContainerStateStatusEnum::EXITED) => {
-                            state.exit_code.map(|c| i32::try_from(c).unwrap_or(0))
-                        }
-                        _ => None,
+                    if info.running == Some(true) {
+                        None
+                    } else {
+                        info.exit_code.map(|c| i32::try_from(c).unwrap_or(0))
                     }
                 }
                 Err(_) => None,
@@ -380,19 +476,7 @@ impl BackgroundHandle for ContainerBackgroundHandle {
 
 impl Drop for ContainerBackgroundHandle {
     fn drop(&mut self) {
-        let container_id = self.container_id.clone();
-        let docker = self.docker.clone();
-        let _ = self.runtime.block_on(async move {
-            docker
-                .remove_container(
-                    &container_id,
-                    Some(RemoveContainerOptions {
-                        force: true,
-                        ..Default::default()
-                    }),
-                )
-                .await
-        });
+        self.kill();
     }
 }
 
@@ -414,7 +498,7 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
             .expect("executor to be created");
 
         let output = executor
@@ -431,7 +515,7 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
             .expect("executor to be created");
 
         let output = executor
@@ -447,7 +531,7 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
             .expect("executor to be created");
 
         let output = executor
@@ -469,6 +553,7 @@ mod tests {
             &[("MESSAGE".to_string(), "hello".to_string())],
             &[],
             &[],
+            &[],
         )
         .expect("executor to be created");
 
@@ -481,11 +566,37 @@ mod tests {
 
     #[test]
     #[ignore = "requires Docker daemon"]
+    fn container_executor_persists_state_across_script_blocks() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
+            .expect("executor to be created");
+
+        // Write a file in the first script block
+        executor
+            .execute(&ScriptCode(
+                "echo 'persisted' > /tmp/test_persistence.txt".to_string(),
+            ))
+            .expect("first execution to succeed");
+
+        // Read it back in a second script block — this only works if
+        // the same container is reused.
+        let output = executor
+            .execute(&ScriptCode("cat /tmp/test_persistence.txt".to_string()))
+            .expect("second execution to succeed");
+
+        assert_eq!(output.stdout, "persisted\n");
+        assert_eq!(output.exit_code, Some(0));
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
     fn container_executor_spawns_and_stops_background_container() {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
             .expect("executor to be created");
 
         let mut handle = executor

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -12,10 +12,22 @@
 //! blocks reuse this container via the Docker **exec** API, so filesystem
 //! state (files, environment, etc.) persists across script blocks within
 //! a spec file run.
+//!
+//! ## Parallel Execution
+//!
+//! When specdown runs with `--jobs > 1`, each parallel spec file gets its
+//! own `ContainerExecutor` instance (via [`Executor::clone_box`]), which in
+//! turn creates a uniquely-named container following the pattern
+//! `specdown-{file-hash}-{counter}`. The file hash is derived from the spec
+//! file path, making containers identifiable per spec file. This prevents
+//! container name collisions and ensures complete isolation between parallel
+//! spec files. Each container is cleaned up when its executor is dropped
+//! (after the spec file completes).
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 use bollard::container::{
     Config, CreateContainerOptions, LogOutput, RemoveContainerOptions, StartContainerOptions,
@@ -34,6 +46,24 @@ use std::convert::TryFrom;
 
 /// Monotonically increasing counter for unique background PID-file names.
 static BG_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Monotonically increasing counter for unique container names.
+static CONTAINER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Hash a label string into a short, stable hex string.
+///
+/// Uses the FNV-1a hash algorithm — fast, dependency-free, and sufficient
+/// for distinguishing spec files in container names. The result is 8 hex
+/// characters (32 bits), which is enough to avoid collisions in practice
+/// for the small number of spec files processed in a single run.
+fn hash_label(label: &str) -> String {
+    let mut hash: u32 = 0x811c_9dc5;
+    for byte in label.as_bytes() {
+        hash = hash.wrapping_mul(0x0100_0193);
+        hash ^= u32::from(*byte);
+    }
+    format!("{hash:08x}")
+}
 
 /// An executor that runs scripts inside a Docker container, communicating
 /// with the Docker daemon over its socket API.
@@ -54,7 +84,10 @@ pub struct ContainerExecutor {
     runtime: tokio::runtime::Runtime,
     docker: Docker,
     /// ID of the persistent container, created on first use.
-    container_id: std::cell::RefCell<Option<String>>,
+    container_id: Mutex<Option<String>>,
+    /// Label used to derive a unique container name (typically the
+    /// spec file path). Incorporated into the container name as a hash.
+    label: String,
 }
 
 impl ContainerExecutor {
@@ -82,6 +115,7 @@ impl ContainerExecutor {
         unset_env: &[String],
         paths: &[P],
         binds: &[String],
+        label: &str,
     ) -> Result<Self, Error>
     where
         P: AsRef<std::ffi::OsStr>,
@@ -122,7 +156,8 @@ impl ContainerExecutor {
             working_dir: "/workspace".to_string(),
             runtime,
             docker,
-            container_id: std::cell::RefCell::new(None),
+            container_id: Mutex::new(None),
+            label: label.to_string(),
         })
     }
 
@@ -168,6 +203,19 @@ impl ContainerExecutor {
         words
     }
 
+    /// Generate a unique container name following the pattern
+    /// `specdown-{file-hash}-{counter}`.
+    ///
+    /// The `label` (typically the spec file path) is hashed with a
+    /// non-cryptographic hash to produce a short, stable identifier for
+    /// the spec file. The counter ensures uniqueness even if the same
+    /// spec file is run multiple times concurrently.
+    fn unique_container_name(label: &str) -> String {
+        let counter = CONTAINER_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let hash = hash_label(label);
+        format!("specdown-{hash}-{counter}")
+    }
+
     /// Return the ID of the persistent container, creating and starting it
     /// if it does not yet exist.
     ///
@@ -176,7 +224,12 @@ impl ContainerExecutor {
     /// script and background blocks in a spec file.
     fn ensure_container(&self) -> Result<String, Error> {
         // Fast path: container already created.
-        if let Some(id) = self.container_id.borrow().clone() {
+        if let Some(id) = self
+            .container_id
+            .lock()
+            .expect("container_id mutex poisoned")
+            .clone()
+        {
             return Ok(id);
         }
 
@@ -185,6 +238,7 @@ impl ContainerExecutor {
         let env = self.container_env();
         let working_dir = self.working_dir.clone();
         let binds = self.binds.clone();
+        let container_name = Self::unique_container_name(&self.label);
 
         let container_id = self.runtime.block_on(async move {
             let config = Config {
@@ -204,7 +258,13 @@ impl ContainerExecutor {
             };
 
             let create_result = docker
-                .create_container(None::<CreateContainerOptions<String>>, config)
+                .create_container(
+                    Some(CreateContainerOptions {
+                        name: container_name,
+                        platform: None,
+                    }),
+                    config,
+                )
                 .await
                 .map_err(|err| Error::SpawnFailed {
                     message: format!("Failed to create persistent container: {err}"),
@@ -220,7 +280,10 @@ impl ContainerExecutor {
             Ok::<String, Error>(create_result.id)
         })?;
 
-        *self.container_id.borrow_mut() = Some(container_id.clone());
+        *self
+            .container_id
+            .lock()
+            .expect("container_id mutex poisoned") = Some(container_id.clone());
         Ok(container_id)
     }
 }
@@ -372,12 +435,50 @@ impl Executor for ContainerExecutor {
             runtime: handle_runtime,
         }) as Box<dyn BackgroundHandle>)
     }
+
+    fn clone_box(&self, label: &str) -> Box<dyn Executor> {
+        // Create a new ContainerExecutor with the same configuration.
+        // Each clone gets its own container (created lazily on first use)
+        // with a unique name derived from the label, ensuring isolation
+        // in parallel execution.
+        let paths: Vec<String> = self
+            .paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        let env: Vec<(String, String)> = self
+            .env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        ContainerExecutor::new::<String>(
+            &self.image,
+            &self.shell_command,
+            &env,
+            &self.unset_env,
+            &paths,
+            &self.binds,
+            label,
+        )
+        .map(|e| Box::new(e) as Box<dyn Executor>)
+        .unwrap_or_else(|err| {
+            // If we can't create a new executor, create a dummy that
+            // returns the error on first use. This should be extremely rare.
+            Box::new(super::executor::FailedExecutor(err))
+        })
+    }
 }
 
 impl Drop for ContainerExecutor {
     fn drop(&mut self) {
         let docker = self.docker.clone();
-        if let Some(container_id) = self.container_id.borrow().clone() {
+        if let Some(container_id) = self
+            .container_id
+            .lock()
+            .expect("container_id mutex poisoned")
+            .clone()
+        {
             let _ = self.runtime.block_on(async move {
                 docker
                     .remove_container(
@@ -498,8 +599,16 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
-            .expect("executor to be created");
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-simple",
+        )
+        .expect("executor to be created");
 
         let output = executor
             .execute(&ScriptCode("echo hello".to_string()))
@@ -515,8 +624,16 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
-            .expect("executor to be created");
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-stderr",
+        )
+        .expect("executor to be created");
 
         let output = executor
             .execute(&ScriptCode("echo 'error' >&2".to_string()))
@@ -531,8 +648,9 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
-            .expect("executor to be created");
+        let executor =
+            ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[], "test-exit")
+                .expect("executor to be created");
 
         let output = executor
             .execute(&ScriptCode("exit 42".to_string()))
@@ -554,6 +672,7 @@ mod tests {
             &[],
             &[],
             &[],
+            "test-env",
         )
         .expect("executor to be created");
 
@@ -570,8 +689,16 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
-            .expect("executor to be created");
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-persist",
+        )
+        .expect("executor to be created");
 
         // Write a file in the first script block
         executor
@@ -596,8 +723,9 @@ mod tests {
         if !docker_available() {
             return;
         }
-        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[])
-            .expect("executor to be created");
+        let executor =
+            ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[], &[], "test-bg")
+                .expect("executor to be created");
 
         let mut handle = executor
             .spawn(&ScriptCode("sleep 60".to_string()))
@@ -605,5 +733,40 @@ mod tests {
 
         handle.kill();
         let _ = handle.wait();
+    }
+
+    #[test]
+    fn container_name_includes_file_hash() {
+        // The hash function is deterministic — same label produces same hash.
+        let hash1 = super::hash_label("specs/test1.md");
+        let hash2 = super::hash_label("specs/test1.md");
+        assert_eq!(hash1, hash2, "same label should produce same hash");
+
+        // Different labels produce different hashes.
+        let hash3 = super::hash_label("specs/test2.md");
+        assert_ne!(
+            hash1, hash3,
+            "different labels should produce different hashes"
+        );
+
+        // Hash is 8 hex characters.
+        assert_eq!(hash1.len(), 8, "hash should be 8 hex characters");
+        assert!(
+            hash1.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash should be hex: {}",
+            hash1
+        );
+    }
+
+    #[test]
+    fn container_name_format_is_correct() {
+        // Verify the naming pattern: specdown-{hash}-{counter}
+        // We can't call unique_container_name directly because it uses
+        // a global counter, but we can verify the format via hash_label.
+        let hash = super::hash_label("specs/my_spec.md");
+        assert!(
+            hash.starts_with(|c: char| c.is_ascii_hexdigit()),
+            "hash should start with a hex digit"
+        );
     }
 }

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -1,0 +1,498 @@
+//! Container executor that runs spec scripts inside a Docker container
+//! using the Docker Engine API via the `bollard` crate.
+//!
+//! This executor connects directly to the Docker socket
+//! (`/var/run/docker.sock` on Linux) and manages containers through the
+//! API — it does NOT shell out to `docker run`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use bollard::container::{
+    AttachContainerOptions, AttachContainerResults, Config, CreateContainerOptions, LogOutput,
+    RemoveContainerOptions,
+};
+use bollard::Docker;
+
+use crate::types::ScriptCode;
+
+use super::background_handle::BackgroundHandle;
+use super::executor::Output;
+use super::{Error, Executor};
+use futures_util::StreamExt;
+use std::convert::TryFrom;
+
+/// An executor that runs scripts inside a Docker container, communicating
+/// with the Docker daemon over its socket API.
+///
+/// Created with [`ContainerExecutor::new`], which establishes a connection
+/// to the Docker daemon.
+#[derive(Debug)]
+pub struct ContainerExecutor {
+    image: String,
+    shell_command: String,
+    env: HashMap<String, String>,
+    unset_env: Vec<String>,
+    paths: Vec<PathBuf>,
+    runtime: tokio::runtime::Runtime,
+    docker: Docker,
+}
+
+impl ContainerExecutor {
+    /// Create a new `ContainerExecutor`.
+    ///
+    /// # Arguments
+    ///
+    /// * `image` - The Docker image to use (e.g. `"bash:5"`).
+    /// * `shell_command` - The shell command to run inside the container
+    ///   (e.g. `"bash -c"`).
+    /// * `env` - Environment variables to set, as `(KEY, VALUE)` pairs.
+    /// * `unset_env` - Environment variables to unset.
+    /// * `paths` - Additional paths to prepend to `PATH`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection to the Docker daemon fails or
+    /// the tokio runtime cannot be created.
+    pub fn new<P>(
+        image: &str,
+        shell_command: &str,
+        env: &[(String, String)],
+        unset_env: &[String],
+        paths: &[P],
+    ) -> Result<Self, Error>
+    where
+        P: AsRef<std::ffi::OsStr>,
+    {
+        // Check that the Docker socket exists before attempting a connection
+        let docker_socket = std::path::Path::new("/var/run/docker.sock");
+        if !docker_socket.exists() {
+            return Err(Error::DockerNotAvailable {
+                message: "Docker socket not found at /var/run/docker.sock".to_string(),
+            });
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| Error::SpawnFailed {
+                message: format!("Failed to create tokio runtime: {err}"),
+            })?;
+
+        let docker =
+            Docker::connect_with_socket_defaults().map_err(|err| Error::DockerNotAvailable {
+                message: format!("Failed to connect to Docker daemon: {err}"),
+            })?;
+
+        let shell_command = if shell_command.is_empty() {
+            "bash -c".to_string()
+        } else {
+            shell_command.to_string()
+        };
+
+        Ok(Self {
+            image: image.to_string(),
+            shell_command,
+            env: env.iter().cloned().collect(),
+            unset_env: unset_env.to_vec(),
+            paths: paths.iter().map(PathBuf::from).collect(),
+            runtime,
+            docker,
+        })
+    }
+
+    /// Build the environment variable list for the container, applying the
+    /// same semantics as `ShellExecutor`: extra paths are prepended to
+    /// `PATH`, and `unset_env` variables are removed.
+    fn container_env(&self) -> Vec<String> {
+        let mut result: Vec<String> = self
+            .env
+            .iter()
+            .filter(|(k, _)| !self.unset_env.contains(k))
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+
+        // Build the PATH variable the same way ShellExecutor does
+        let mut path_parts: Vec<String> = self
+            .paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        if let Ok(current_path) = std::env::var("PATH") {
+            path_parts.push(current_path);
+        }
+
+        let path_var = path_parts.join(":");
+        result.push(format!("PATH={path_var}"));
+
+        result
+    }
+
+    /// Build the container command from the shell command string.
+    ///
+    /// Splits the shell command (e.g. `"bash -c"`) into entrypoint + cmd
+    /// parts, then appends the script code as the final argument.
+    fn container_command(&self, code: &str) -> (Vec<String>, Vec<String>) {
+        let words = shell_words::split(&self.shell_command).unwrap_or_default();
+        if words.is_empty() {
+            return (
+                vec!["bash".to_string()],
+                vec!["-c".to_string(), code.to_string()],
+            );
+        }
+
+        let (entrypoint, cmd) = words.split_at(1);
+        let mut cmd = cmd.to_vec();
+        cmd.push(code.to_string());
+
+        (entrypoint.to_vec(), cmd)
+    }
+
+    /// Build a `Config` for the Docker container.
+    fn container_config(&self, code: &str) -> Config<String> {
+        let (entrypoint, cmd) = self.container_command(code);
+        let env = self.container_env();
+
+        Config {
+            image: Some(self.image.clone()),
+            entrypoint: Some(entrypoint),
+            cmd: Some(cmd),
+            env: Some(env),
+            attach_stdout: Some(true),
+            attach_stderr: Some(true),
+            open_stdin: Some(false),
+            stdin_once: Some(false),
+            tty: Some(false),
+            ..Default::default()
+        }
+    }
+}
+
+impl Executor for ContainerExecutor {
+    fn execute(&self, script: &ScriptCode) -> Result<Output, Error> {
+        let ScriptCode(code_string) = script;
+
+        let config = self.container_config(code_string);
+
+        let docker = self.docker.clone();
+
+        self.runtime.block_on(async move {
+            // Create the container
+            let create_result = docker
+                .create_container(None::<CreateContainerOptions<String>>, config)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to create container: {err}"),
+                })?;
+
+            let container_id = create_result.id;
+
+            // Attach to the container to capture stdout/stderr
+            let attach_options = Some(AttachContainerOptions::<String> {
+                stdin: Some(false),
+                stdout: Some(true),
+                stderr: Some(true),
+                stream: Some(true),
+                logs: Some(false),
+                detach_keys: None,
+            });
+
+            let AttachContainerResults { output, .. } = docker
+                .attach_container(&container_id, attach_options)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to attach to container: {err}"),
+                })?;
+
+            // Start the container
+            docker
+                .start_container(
+                    &container_id,
+                    None::<bollard::container::StartContainerOptions<String>>,
+                )
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start container: {err}"),
+                })?;
+
+            // Collect stdout and stderr from the attach stream
+            let mut stdout = String::new();
+            let mut stderr = String::new();
+
+            let mut output = output;
+            while let Some(msg) = output.next().await {
+                match msg {
+                    Ok(LogOutput::StdOut { message }) => {
+                        stdout.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    Ok(LogOutput::StdErr { message }) => {
+                        stderr.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        stderr.push_str("Error reading container output: ");
+                        stderr.push_str(&err.to_string());
+                        stderr.push('\n');
+                    }
+                }
+            }
+
+            // Wait for the container to exit and get the exit code
+            let wait_stream = docker.wait_container(
+                &container_id,
+                None::<bollard::container::WaitContainerOptions<String>>,
+            );
+            let exit_code = {
+                futures_util::pin_mut!(wait_stream);
+                let mut code = None;
+                while let Some(msg) = wait_stream.next().await {
+                    if let Ok(response) = msg {
+                        code = Some(i32::try_from(response.status_code).unwrap_or(0));
+                        break;
+                    }
+                }
+                code
+            };
+
+            // Remove the container (force, in case it's still running)
+            let _ = docker
+                .remove_container(
+                    &container_id,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await;
+
+            Ok(Output {
+                stdout,
+                stderr,
+                exit_code,
+            })
+        })
+    }
+
+    fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
+        let ScriptCode(code_string) = script;
+
+        let config = self.container_config(code_string);
+
+        let docker = self.docker.clone();
+
+        self.runtime.block_on(async move {
+            // Create the container
+            let create_result = docker
+                .create_container(None::<CreateContainerOptions<String>>, config)
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to create container: {err}"),
+                })?;
+
+            let container_id = create_result.id;
+
+            // Start the container
+            docker
+                .start_container(
+                    &container_id,
+                    None::<bollard::container::StartContainerOptions<String>>,
+                )
+                .await
+                .map_err(|err| Error::SpawnFailed {
+                    message: format!("Failed to start container: {err}"),
+                })?;
+
+            Ok(Box::new(ContainerBackgroundHandle {
+                container_id,
+                docker,
+                runtime: tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|err| Error::SpawnFailed {
+                        message: format!("Failed to create runtime for background handle: {err}"),
+                    })?,
+            }) as Box<dyn BackgroundHandle>)
+        })
+    }
+}
+
+/// A handle to a background Docker container that can be killed and waited on.
+#[derive(Debug)]
+pub struct ContainerBackgroundHandle {
+    container_id: String,
+    docker: Docker,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl BackgroundHandle for ContainerBackgroundHandle {
+    fn kill(&mut self) {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        let _ = self.runtime.block_on(async move {
+            docker
+                .kill_container(
+                    &container_id,
+                    None::<bollard::container::KillContainerOptions<String>>,
+                )
+                .await
+        });
+    }
+
+    fn wait(&mut self) -> Option<i32> {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        self.runtime.block_on(async move {
+            use futures_util::StreamExt;
+            let mut stream = docker.wait_container(
+                &container_id,
+                None::<bollard::container::WaitContainerOptions<String>>,
+            );
+            stream
+                .next()
+                .await
+                .and_then(std::result::Result::ok)
+                .map(|r| i32::try_from(r.status_code).unwrap_or(0))
+        })
+        // Container may have already been removed; return None
+    }
+
+    fn try_wait(&mut self) -> Option<i32> {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        self.runtime.block_on(async move {
+            // Inspect the container to check if it has exited
+            match docker.inspect_container(&container_id, None).await {
+                Ok(info) => {
+                    let state = info.state?;
+                    match state.status {
+                        Some(bollard::models::ContainerStateStatusEnum::EXITED) => {
+                            state.exit_code.map(|c| i32::try_from(c).unwrap_or(0))
+                        }
+                        _ => None,
+                    }
+                }
+                Err(_) => None,
+            }
+        })
+    }
+}
+
+impl Drop for ContainerBackgroundHandle {
+    fn drop(&mut self) {
+        let container_id = self.container_id.clone();
+        let docker = self.docker.clone();
+        let _ = self.runtime.block_on(async move {
+            docker
+                .remove_container(
+                    &container_id,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ContainerExecutor, Executor, ScriptCode};
+    use std::path::PathBuf;
+
+    // These tests require a running Docker daemon.
+    // They are ignored by default; run with `cargo test -- --ignored`.
+
+    fn docker_available() -> bool {
+        std::path::Path::new("/var/run/docker.sock").exists()
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_executes_simple_command() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("echo hello".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.stdout, "hello\n");
+        assert_eq!(output.exit_code, Some(0));
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_captures_stderr() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("echo 'error' >&2".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.stderr, "error\n");
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_captures_exit_code() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("exit 42".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.exit_code, Some(42));
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_sets_environment_variables() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[("MESSAGE".to_string(), "hello".to_string())],
+            &[],
+            &[],
+        )
+        .expect("executor to be created");
+
+        let output = executor
+            .execute(&ScriptCode("echo $MESSAGE".to_string()))
+            .expect("execution to succeed");
+
+        assert_eq!(output.stdout, "hello\n");
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_spawns_and_stops_background_container() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>("bash:5", "bash -c", &[], &[], &[])
+            .expect("executor to be created");
+
+        let mut handle = executor
+            .spawn(&ScriptCode("sleep 60".to_string()))
+            .expect("spawn to succeed");
+
+        handle.kill();
+        let _ = handle.wait();
+    }
+}

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -461,12 +461,14 @@ impl Executor for ContainerExecutor {
             &self.binds,
             label,
         )
-        .map(|e| Box::new(e) as Box<dyn Executor>)
-        .unwrap_or_else(|err| {
-            // If we can't create a new executor, create a dummy that
-            // returns the error on first use. This should be extremely rare.
-            Box::new(super::executor::FailedExecutor(err))
-        })
+        .map_or_else(
+            |err| {
+                // If we can't create a new executor, create a dummy that
+                // returns the error on first use. This should be extremely rare.
+                Box::new(super::executor::FailedExecutor(err)) as Box<dyn Executor>
+            },
+            |e| Box::new(e) as Box<dyn Executor>,
+        )
     }
 }
 

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     BadShellCommand { command: String, message: String },
     #[error("Background scripts are not supported with this executor")]
     BackgroundNotSupported,
+    #[error("The mock server has not been started")]
+    MockServerNotStarted,
     #[error("Failed to spawn background process: {message}")]
     SpawnFailed { message: String },
     #[cfg(feature = "container")]

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -14,4 +14,10 @@ pub enum Error {
     BackgroundNotSupported,
     #[error("Failed to spawn background process: {message}")]
     SpawnFailed { message: String },
+    #[cfg(feature = "container")]
+    #[error("The container executor requires Docker, but it is not available: {message}")]
+    DockerNotAvailable { message: String },
+    #[cfg(not(feature = "container"))]
+    #[error("The container executor feature is not enabled. Rebuild specdown with `--features container`")]
+    ContainerFeatureNotEnabled,
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -30,4 +30,38 @@ pub trait Executor: Send + Sync {
         let _ = script;
         Err(Error::BackgroundNotSupported)
     }
+
+    /// Create a boxed clone of this executor.
+    ///
+    /// Used when running spec files in parallel (`--jobs > 1`): each
+    /// parallel spec file gets its own executor instance via this method
+    /// so that stateful executors (e.g. the container executor, which
+    /// manages a Docker container) get complete isolation between
+    /// concurrent spec files.
+    ///
+    /// The `label` argument is the spec file path (or other identifying
+    /// string). The container executor incorporates a hash of this label
+    /// into the container name (`specdown-{hash}-{counter}`) so that
+    /// containers are uniquely identifiable per spec file.
+    ///
+    /// The default implementation returns a `FailedExecutor` that produces
+    /// a `BackgroundNotSupported` error on first use. Executors that support
+    /// parallel execution should override this.
+    fn clone_box(&self, _label: &str) -> Box<dyn Executor> {
+        let _ = _label;
+        Box::new(FailedExecutor(Error::BackgroundNotSupported))
+    }
+}
+
+/// A fallback executor that always returns a pre-set error.
+///
+/// Used as the default `clone_box` implementation for executors that do
+/// not support cloning (and therefore cannot be used in parallel mode).
+#[derive(Debug)]
+pub struct FailedExecutor(pub Error);
+
+impl Executor for FailedExecutor {
+    fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+        Err(self.0.clone())
+    }
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -1,7 +1,6 @@
-use std::process::Child;
-
 use crate::types::ScriptCode;
 
+use super::background_handle::BackgroundHandle;
 use super::Error;
 
 pub struct Output {
@@ -27,7 +26,7 @@ impl From<std::process::Output> for Output {
 pub trait Executor: Send + Sync {
     fn execute(&self, script: &ScriptCode) -> Result<Output, Error>;
 
-    fn spawn(&self, script: &ScriptCode) -> Result<Child, Error> {
+    fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
         let _ = script;
         Err(Error::BackgroundNotSupported)
     }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -47,8 +47,8 @@ pub trait Executor: Send + Sync {
     /// The default implementation returns a `FailedExecutor` that produces
     /// a `BackgroundNotSupported` error on first use. Executors that support
     /// parallel execution should override this.
-    fn clone_box(&self, _label: &str) -> Box<dyn Executor> {
-        let _ = _label;
+    fn clone_box(&self, label: &str) -> Box<dyn Executor> {
+        let _ = label;
         Box::new(FailedExecutor(Error::BackgroundNotSupported))
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -9,6 +9,9 @@ pub use state::State;
 use crate::types::Action;
 
 mod background;
+mod background_handle;
+#[cfg(feature = "container")]
+pub(crate) mod container_executor;
 mod error;
 mod executor;
 mod file;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6,6 +6,7 @@ pub use run_event::RunEvent;
 pub use runnable_action::to_runnable;
 pub use state::State;
 
+use crate::results::{ActionResult, ResponseResult, ResponseStatus};
 use crate::types::Action;
 
 mod background;
@@ -63,6 +64,17 @@ impl<'a> Runner<'a> {
                 }
                 Err(error) => RunEvent::ErrorOccurred(error),
             },
+            Action::Response(resp_action) => {
+                // Response actions require a mock server which is not yet
+                // implemented. Return an unpaired result so the error is
+                // visible in test output.
+                let result = ActionResult::Response(ResponseResult {
+                    name: resp_action.name.clone(),
+                    status: ResponseStatus::Unpaired,
+                });
+                self.state.add_result(&result);
+                RunEvent::TestCompleted(result)
+            }
             _ => to_runnable(action)
                 .run(self.state, self.executor)
                 .map(|result| {

--- a/src/runner/runnable_action.rs
+++ b/src/runner/runnable_action.rs
@@ -1,5 +1,7 @@
 use crate::results::ActionResult;
-use crate::types::{Action, BackgroundAction, CreateFileAction, ScriptAction, VerifyAction};
+use crate::types::{
+    Action, BackgroundAction, CreateFileAction, ResponseAction, ScriptAction, VerifyAction,
+};
 
 use super::{error, file, script, verify, Error, Executor, State};
 
@@ -9,6 +11,7 @@ pub fn to_runnable(action: &Action) -> &dyn RunnableAction {
         Action::Verify(a) => a,
         Action::CreateFile(a) => a,
         Action::Background(a) => a,
+        Action::Response(a) => a,
     }
 }
 
@@ -40,5 +43,14 @@ impl RunnableAction for BackgroundAction {
         // not through the normal RunnableAction trait.
         // This implementation should not be reached.
         Err(Error::BackgroundNotSupported)
+    }
+}
+
+impl RunnableAction for ResponseAction {
+    fn run(&self, _state: &State, _executor: &dyn Executor) -> Result<ActionResult, Error> {
+        // Response actions require the mock server, which is not part of this
+        // task. The Runner handles them specially (like Background actions);
+        // reaching this trait method means the mock server was never started.
+        Err(Error::MockServerNotStarted)
     }
 }

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -135,6 +135,32 @@ impl Executor for ShellExecutor {
                 message: err.to_string(),
             })
     }
+
+    fn clone_box(&self, _label: &str) -> Box<dyn Executor> {
+        // ShellExecutor is stateless (each execute() spawns a fresh process),
+        // so cloning just creates a new instance with the same configuration.
+        // The label is not used since the shell executor has no persistent state
+        // to namespace.
+        let env: Vec<(String, String)> = self
+            .env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let paths: Vec<String> = self
+            .paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        let shell_cmd = if self.args.is_empty() {
+            self.command.clone()
+        } else {
+            format!("{} {}", self.command, self.args.join(" "))
+        };
+
+        ShellExecutor::new::<String>(&shell_cmd, &env, &self.unset_env, &paths)
+            .map(|e| Box::new(e) as Box<dyn Executor>)
+            .unwrap_or_else(|err| Box::new(super::executor::FailedExecutor(err)))
+    }
 }
 
 #[cfg(test)]

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -157,9 +157,10 @@ impl Executor for ShellExecutor {
             format!("{} {}", self.command, self.args.join(" "))
         };
 
-        ShellExecutor::new::<String>(&shell_cmd, &env, &self.unset_env, &paths)
-            .map(|e| Box::new(e) as Box<dyn Executor>)
-            .unwrap_or_else(|err| Box::new(super::executor::FailedExecutor(err)))
+        ShellExecutor::new::<String>(&shell_cmd, &env, &self.unset_env, &paths).map_or_else(
+            |err| Box::new(super::executor::FailedExecutor(err)) as Box<dyn Executor>,
+            |e| Box::new(e) as Box<dyn Executor>,
+        )
     }
 }
 

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -5,6 +5,7 @@ use shell_words::ParseError;
 
 use crate::types::ScriptCode;
 
+use super::background_handle::BackgroundHandle;
 use super::executor::Output;
 use super::{Error, Executor};
 use std::env;
@@ -120,16 +121,19 @@ impl Executor for ShellExecutor {
             })
     }
 
-    fn spawn(&self, script: &ScriptCode) -> Result<std::process::Child, Error> {
+    fn spawn(&self, script: &ScriptCode) -> Result<Box<dyn BackgroundHandle>, Error> {
         let ScriptCode(code_string) = script;
 
         let mut command = self.build_command(code_string);
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
 
-        command.spawn().map_err(|err| Error::SpawnFailed {
-            message: err.to_string(),
-        })
+        command
+            .spawn()
+            .map(|child| Box::new(child) as Box<dyn BackgroundHandle>)
+            .map_err(|err| Error::SpawnFailed {
+                message: err.to_string(),
+            })
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Stream {
     StdOut,
@@ -119,17 +121,164 @@ pub struct BackgroundAction {
     pub script_code: ScriptCode,
 }
 
+/// The name of a mock endpoint, used to pair request and response blocks.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MockName(pub String);
+
+impl From<MockName> for String {
+    fn from(mock_name: MockName) -> Self {
+        let MockName(value) = mock_name;
+        value
+    }
+}
+
+impl From<&MockName> for String {
+    fn from(mock_name: &MockName) -> Self {
+        let MockName(value) = mock_name;
+        value.clone()
+    }
+}
+
+impl std::fmt::Display for MockName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let MockName(value) = self;
+        write!(f, "{value}")
+    }
+}
+
+/// An HTTP status code. Validated to the range 100..=599 at parse time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StatusCode(pub u16);
+
+/// Error returned when a status code is outside the valid range.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StatusCodeError {
+    pub value: i32,
+}
+
+impl StatusCodeError {
+    #[must_use]
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+}
+
+impl StatusCode {
+    /// Parse an integer into a `StatusCode`, validating the HTTP range 100..=599.
+    pub fn parse(value: i32) -> Result<Self, StatusCodeError> {
+        if (100..=599).contains(&value) {
+            Ok(StatusCode(u16::try_from(value).expect("validated range")))
+        } else {
+            Err(StatusCodeError { value })
+        }
+    }
+}
+
+impl Default for StatusCode {
+    fn default() -> Self {
+        StatusCode(200)
+    }
+}
+
+/// A response header. The name is stored lower-cased per HTTP convention.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResponseHeader {
+    pub name: String,
+    pub value: String,
+}
+
+/// A delay in milliseconds applied before a mock response is sent.
+/// Capped at `300_000` (5 minutes) at parse time.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct DelayMillis(pub u32);
+
+/// Error returned when a delay value exceeds the maximum.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelayMillisError {
+    pub value: i32,
+}
+
+impl DelayMillisError {
+    #[must_use]
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+}
+
+/// Maximum allowed delay in milliseconds (5 minutes).
+pub const MAX_DELAY_MILLIS: i32 = 300_000;
+
+impl DelayMillis {
+    /// Parse an integer into a `DelayMillis`, capping at `MAX_DELAY_MILLIS`.
+    pub fn parse(value: i32) -> Result<Self, DelayMillisError> {
+        if !(0..=MAX_DELAY_MILLIS).contains(&value) {
+            return Err(DelayMillisError { value });
+        }
+        Ok(DelayMillis(
+            u32::try_from(value).expect("validated non-negative"),
+        ))
+    }
+}
+
+impl std::fmt::Display for StatusCodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid status code: {}", self.value())
+    }
+}
+
+impl std::fmt::Display for DelayMillisError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid delay: {}ms", self.value())
+    }
+}
+
+/// The body of a mock response.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ResponseBody {
+    /// Body taken from the code block literal.
+    Literal(String),
+    /// Reserved for a future `body="..."` argument — not wired in v1.
+    Inline(String),
+    /// No body (empty literal).
+    Empty,
+}
+
+/// A parsed `response` code block — the raw values before action decoding.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResponseCodeBlock {
+    pub name: MockName,
+    pub status: StatusCode,
+    pub headers: Option<String>,
+    pub content_type: Option<String>,
+    pub delay: DelayMillis,
+    pub body: ResponseBody,
+}
+
+/// A decoded response action — headers expanded, body resolved.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResponseAction {
+    pub name: MockName,
+    pub status: StatusCode,
+    pub headers: Vec<ResponseHeader>,
+    pub delay: DelayMillis,
+    pub body: ResponseBody,
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum Action {
     Script(ScriptAction),
     Verify(VerifyAction),
     CreateFile(CreateFileAction),
     Background(BackgroundAction),
+    Response(ResponseAction),
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ExitCode, FilePath, ScriptName, Source, Stream, VerifyAction, VerifyValue};
+    use super::{
+        DelayMillis, ExitCode, FilePath, MockName, ResponseBody, ScriptName, Source, StatusCode,
+        Stream, VerifyAction, VerifyValue,
+    };
 
     mod script_name {
         use super::ScriptName;
@@ -213,6 +362,178 @@ mod tests {
                 },
                 action.with_script_name(Some(ScriptName("new_name".to_string())))
             );
+        }
+    }
+
+    mod mock_name {
+        use super::MockName;
+
+        #[test]
+        fn converts_to_string_from_mock_name() {
+            assert_eq!(
+                String::from(MockName("my-mock".to_string())),
+                String::from("my-mock")
+            );
+        }
+
+        #[test]
+        fn converts_to_string_from_mock_name_reference() {
+            assert_eq!(
+                String::from(&MockName("my-mock".to_string())),
+                String::from("my-mock")
+            );
+        }
+
+        #[test]
+        fn displays_as_the_inner_string() {
+            assert_eq!(format!("{}", MockName("hello".to_string())), "hello");
+        }
+
+        #[test]
+        fn equal_when_inner_strings_are_equal() {
+            assert_eq!(
+                MockName("list-users".to_string()),
+                MockName("list-users".to_string())
+            );
+        }
+
+        #[test]
+        fn not_equal_when_inner_strings_differ() {
+            assert_ne!(
+                MockName("list-users".to_string()),
+                MockName("get-user".to_string())
+            );
+        }
+    }
+
+    mod status_code {
+        use super::StatusCode;
+
+        #[test]
+        fn parse_accepts_a_valid_status_code() {
+            assert_eq!(StatusCode(200), StatusCode::parse(200).unwrap());
+        }
+
+        #[test]
+        fn parse_accepts_the_minimum_valid_status_code() {
+            assert_eq!(StatusCode(100), StatusCode::parse(100).unwrap());
+        }
+
+        #[test]
+        fn parse_accepts_the_maximum_valid_status_code() {
+            assert_eq!(StatusCode(599), StatusCode::parse(599).unwrap());
+        }
+
+        #[test]
+        fn parse_rejects_a_status_code_below_the_minimum() {
+            assert!(StatusCode::parse(99).is_err());
+        }
+
+        #[test]
+        fn parse_rejects_zero() {
+            assert!(StatusCode::parse(0).is_err());
+        }
+
+        #[test]
+        fn parse_rejects_a_negative_status_code() {
+            assert!(StatusCode::parse(-1).is_err());
+        }
+
+        #[test]
+        fn parse_rejects_a_status_code_above_the_maximum() {
+            assert!(StatusCode::parse(600).is_err());
+        }
+
+        #[test]
+        fn default_is_200() {
+            assert_eq!(StatusCode(200), StatusCode::default());
+        }
+
+        #[test]
+        fn equality_compares_the_inner_u16() {
+            assert_eq!(StatusCode(404), StatusCode(404));
+            assert_ne!(StatusCode(404), StatusCode(200));
+        }
+
+        #[test]
+        fn parse_error_contains_the_rejected_value() {
+            let err = StatusCode::parse(99).unwrap_err();
+            assert_eq!(99, err.value());
+        }
+    }
+
+    mod delay_millis {
+        use super::DelayMillis;
+
+        #[test]
+        fn parse_accepts_zero() {
+            assert_eq!(DelayMillis(0), DelayMillis::parse(0).unwrap());
+        }
+
+        #[test]
+        fn parse_accepts_the_maximum() {
+            assert_eq!(DelayMillis(300_000), DelayMillis::parse(300_000).unwrap());
+        }
+
+        #[test]
+        fn parse_rejects_a_negative_value() {
+            assert!(DelayMillis::parse(-1).is_err());
+        }
+
+        #[test]
+        fn parse_rejects_a_value_above_the_maximum() {
+            assert!(DelayMillis::parse(300_001).is_err());
+        }
+
+        #[test]
+        fn default_is_zero() {
+            assert_eq!(DelayMillis(0), DelayMillis::default());
+        }
+
+        #[test]
+        fn equality_compares_the_inner_u32() {
+            assert_eq!(DelayMillis(100), DelayMillis(100));
+            assert_ne!(DelayMillis(100), DelayMillis(200));
+        }
+
+        #[test]
+        fn parse_error_contains_the_rejected_value() {
+            let err = DelayMillis::parse(-1).unwrap_err();
+            assert_eq!(-1, err.value());
+        }
+    }
+
+    mod response_body {
+        use super::ResponseBody;
+
+        #[test]
+        fn literal_equality_compares_inner_string() {
+            assert_eq!(
+                ResponseBody::Literal("hello".to_string()),
+                ResponseBody::Literal("hello".to_string())
+            );
+            assert_ne!(
+                ResponseBody::Literal("hello".to_string()),
+                ResponseBody::Literal("world".to_string())
+            );
+        }
+
+        #[test]
+        fn empty_is_equal_to_empty() {
+            assert_eq!(ResponseBody::Empty, ResponseBody::Empty);
+        }
+
+        #[test]
+        fn inline_is_not_equal_to_literal_with_same_content() {
+            assert_ne!(
+                ResponseBody::Inline("data".to_string()),
+                ResponseBody::Literal("data".to_string())
+            );
+        }
+
+        #[test]
+        fn empty_is_not_equal_to_literal_with_empty_string() {
+            assert_ne!(ResponseBody::Empty, ResponseBody::Literal(String::new()));
         }
     }
 }

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -5,13 +5,32 @@ use indoc::formatdoc;
 fn assert_ok(result: &OutputResult) {
     let output = match result {
         Ok(out) => out,
-        Err(err) => err.as_output().unwrap(),
+        Err(err) => err.as_output().expect("failed to get output from error"),
     };
 
     println!("Output:\n{}", String::from_utf8_lossy(&output.stdout));
     println!("Error:\n{}", String::from_utf8_lossy(&output.stderr));
 
     assert!(result.is_ok());
+}
+
+/// Build a `specdown run` command with `--add-path` pointing at the debug binary
+/// so integration tests can find the freshly-built specdown binary.
+fn specdown_run_with_path() -> Command {
+    let bin_dir = std::env::current_dir()
+        .expect("failed to get current directory")
+        .join("target")
+        .join("debug");
+    let mut cmd = Command::cargo_bin("specdown").expect("failed to find specdown cargo binary");
+    cmd.arg("run")
+        .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(
+            bin_dir
+                .to_str()
+                .expect("failed to convert bin_dir to UTF-8 string"),
+        );
+    cmd
 }
 
 #[test]
@@ -54,16 +73,7 @@ fn test_doc_display_help() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_running_specs() {
-    let bin_dir = std::env::current_dir()
-        .unwrap()
-        .join("target")
-        .join("debug");
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
-        .arg("--add-path")
-        .arg(bin_dir.to_str().unwrap())
+    let result = specdown_run_with_path()
         .arg("docs/cli/running_specs.md")
         .ok();
 
@@ -200,16 +210,7 @@ fn test_doc_stripping_specs() {
 
 #[test]
 fn test_doc_background_scripts() {
-    let bin_dir = std::env::current_dir()
-        .unwrap()
-        .join("target")
-        .join("debug");
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
-        .arg("--add-path")
-        .arg(bin_dir.to_str().unwrap())
+    let result = specdown_run_with_path()
         .arg("docs/specs/background_scripts.md")
         .ok();
 
@@ -218,16 +219,7 @@ fn test_doc_background_scripts() {
 
 #[test]
 fn test_doc_container_executor() {
-    let bin_dir = std::env::current_dir()
-        .unwrap()
-        .join("target")
-        .join("debug");
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
-        .arg("--add-path")
-        .arg(bin_dir.to_str().unwrap())
+    let result = specdown_run_with_path()
         .arg("docs/specs/container_executor.md")
         .ok();
 
@@ -256,7 +248,7 @@ fn test_displays_error_when_required_args_are_missing() {
               run         Runs a given Markdown Specification
               strip       Outputs a version of the markdown with all specdown functions removed
               help        Print this message or the help of the given subcommand(s)
-
+            
             Options:
                   --no-colour  Disables coloured output
               -h, --help       Print help

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -143,10 +143,21 @@ fn test_doc_output_expectations() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_errors() {
+    let bin_dir = std::env::current_dir()
+        .expect("failed to get current directory")
+        .join("target")
+        .join("debug");
     let result = Command::cargo_bin("specdown")
         .unwrap()
+        .arg("--no-colour")
         .arg("run")
         .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(
+            bin_dir
+                .to_str()
+                .expect("failed to convert bin_dir to UTF-8 string"),
+        )
         .arg("docs/errors.md")
         .ok();
 

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -54,10 +54,16 @@ fn test_doc_display_help() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_running_specs() {
+    let bin_dir = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("debug");
     let result = Command::cargo_bin("specdown")
         .unwrap()
         .arg("run")
         .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(bin_dir.to_str().unwrap())
         .arg("docs/cli/running_specs.md")
         .ok();
 
@@ -205,6 +211,24 @@ fn test_doc_background_scripts() {
         .arg("--add-path")
         .arg(bin_dir.to_str().unwrap())
         .arg("docs/specs/background_scripts.md")
+        .ok();
+
+    assert_ok(&result);
+}
+
+#[test]
+fn test_doc_container_executor() {
+    let bin_dir = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("debug");
+    let result = Command::cargo_bin("specdown")
+        .unwrap()
+        .arg("run")
+        .arg("--temporary-workspace-dir")
+        .arg("--add-path")
+        .arg(bin_dir.to_str().unwrap())
+        .arg("docs/specs/container_executor.md")
         .ok();
 
     assert_ok(&result);


### PR DESCRIPTION
## Summary

Add a new `response` block type that declares mock HTTP responses for specdown's HTTP API mocking feature. This is part of a request/response block pair — the response block declares the canned reply for a mocked endpoint.

### New types
- `MockName`: pairing key for request/response blocks
- `StatusCode`: HTTP status code (validated 100..=599, default 200)
- `DelayMillis`: response delay in ms (capped at 300000, default 0)
- `ResponseHeader`: literal response header (name lower-cased)
- `ResponseBody`: Literal/Inline/Empty body from code block literal
- `ResponseCodeBlock`: parsed block before action decoding
- `ResponseAction`: decoded action with expanded headers

### Block syntax
```
```<lang>,response(
    name="<string>",            # REQUIRED, pairing key
    status=<integer>,           # OPTIONAL, default 200
    headers="<string>",         # OPTIONAL, semicolon-separated Name:Value
    content_type="<string>",    # OPTIONAL, shorthand for Content-Type
    delay=<integer>             # OPTIONAL, default 0 (ms)
)
<literal — the response body>
```
```

### Design decisions
- `content_type` shorthand folds into headers only if no explicit `Content-Type` header exists (explicit wins)
- Response headers are literal values (no matcher prefixes)
- Empty literal → `ResponseBody::Empty`; non-empty → `ResponseBody::Literal`
- `ResponseBody::Inline` variant reserved for future `body="..."` argument
- Pairing validated at registration time, not parse time
- `UnpairedResponse(MockName)` error when no matching request block exists

## Test Plan
- [x] `cargo test` — 233 tests pass (216 unit + 17 integration)
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic -D clippy::cargo` — 0 errors, 0 warnings
- [x] `cargo fmt --check` — clean

Stacked on top of #591 (container executor) which introduced the `BackgroundHandle` trait pattern this block follows.