### PR TITLE
fix: correct the generated Homebrew formula

### DIFF
--- a/homebrew/formula.rb.j2
+++ b/homebrew/formula.rb.j2
@@ -2,7 +2,21 @@ class Specdown < Formula
   desc "Use your markdown documentation as tests"
   homepage "https://github.com/{{ github_repo }}"
   license "Apache-2.0"
-  depends_on "help2man" => :build
+{# The `help2man` build dependency is disabled, and with it the man page generation in
+   `install` below. Restore both together.
+
+     depends_on "help2man" => :build
+
+   `brew test-bot` only builds a bottle when every build dependency already has a bottle
+   for the exact OS of the runner it is on (see `build_bottle?` in
+   Homebrew/homebrew-test-bot, lib/tests/formulae.rb). help2man publishes no Intel macOS
+   bottle newer than `sonoma`, and the only Intel macOS runners GitHub still offers are
+   `macos-15-intel` and `macos-26-intel`. So while help2man is a build dependency, no
+   Intel macOS bottle for specdown can be produced at all, and test-bot silently skips
+   the formula on those runners rather than installing it.
+
+   Re-enable once help2man ships an Intel bottle for a macOS that GitHub still runs, or
+   once the tap stops building Intel macOS bottles. #}  version_scheme 1
 
   on_macos do
     on_arm do
@@ -12,6 +26,7 @@ class Specdown < Formula
     on_intel do
       url "https://github.com/{{ github_repo }}/releases/download/{{ git_tag }}/specdown-x86_64-apple-darwin"
       sha256 "{{ macos_x86_sha }}"
+      version "{{ version }}"
     end
   end
 
@@ -19,6 +34,7 @@ class Specdown < Formula
     on_intel do
       url "https://github.com/{{ github_repo }}/releases/download/{{ git_tag }}/specdown-x86_64-unknown-linux-gnu"
       sha256 "{{ linux_x86_sha }}"
+      version "{{ version }}"
     end
     on_arm do
       url "https://github.com/{{ github_repo }}/releases/download/{{ git_tag }}/specdown-aarch64-unknown-linux-gnu"
@@ -32,34 +48,25 @@ class Specdown < Formula
   end
 
   def install
-    if OS.mac?
-      if Hardware::CPU.arm?
-        bin.install "specdown-aarch64-apple-darwin" => "specdown"
-      elsif Hardware::CPU.intel?
-        bin.install "specdown-x86_64-apple-darwin" => "specdown"
-      end
-    elsif OS.linux?
-      if Hardware::CPU.intel?
-        bin.install "specdown-x86_64-unknown-linux-gnu" => "specdown"
-      elsif Hardware::CPU.arm?
-        bin.install "specdown-aarch64-unknown-linux-gnu" => "specdown"
-      end
+    binary = if OS.mac?
+      Hardware::CPU.arm? ? "specdown-aarch64-apple-darwin" : "specdown-x86_64-apple-darwin"
+    else
+      Hardware::CPU.arm? ? "specdown-aarch64-unknown-linux-gnu" : "specdown-x86_64-unknown-linux-gnu"
     end
 
-    generate_completions_from_executable(bin/"specdown", "completion", shells: [
-      :bash,
-      :fish,
-      :zsh,
-    ])
+    chmod 0755, binary
+    bin.install binary => "specdown"
 
-    # Man pages
-    output = Utils.safe_popen_read("help2man", "#{bin}/specdown")
+    generate_completions_from_executable(bin/"specdown", "completion")
+{# Man page generation, disabled with the help2man build dependency above.
+
+    output = Utils.safe_popen_read("help2man", bin/"specdown")
     (man1/"specdown.1").write output
-  end
+#}  end
 
   test do
-    system "#{bin}/specdown", "-h"
-    system "#{bin}/specdown", "-V"
+    system bin/"specdown", "-h"
+    system bin/"specdown", "-V"
 
     resource("testdata").stage do
       assert_match "5 functions run (5 succeeded / 0 failed)", shell_output("#{bin}/specdown run README.md")


### PR DESCRIPTION
The Homebrew tap has been shipping a formula that **cannot install** since v1.3.3 was released in May. `brew install specdown/repo/specdown` fails today on macOS and Linux alike.

`Formula/specdown.rb` in `specdown/homebrew-repo` is generated from `homebrew/formula.rb.j2` and copied over wholesale by the `generate-formula` job, so the fix has to land here or the next release re-breaks the tap.

## The bugs

**1. The installed binary is not executable.** `bin.install` is a plain `FileUtils.mv` and does not chmod. The release assets are bare binaries, which download as `0644`, so the installed `specdown` has no executable bit. Every CI run since v1.3.3 contains:

```
brew: exec failed (EACCES): /opt/homebrew/Cellar/specdown/1.3.6/bin/specdown
```

raised as soon as `generate_completions_from_executable` tries to run it. Fixed by `chmod 0755` before `bin.install`.

**2. The version is wrong on x86_64.** With no `version` stanza, Homebrew scans it out of the URL and trips over the `_64` in `x86_64`:

| asset | scanned version |
|---|---|
| `specdown-aarch64-apple-darwin` | `1.6.1` |
| `specdown-x86_64-apple-darwin` | `64-apple-darwin` |
| `specdown-x86_64-unknown-linux-gnu` | `64-unknown-linux-gnu` |
| `specdown-aarch64-unknown-linux-gnu` | `1.6.1` |

Which is why Linux installed to `Cellar/specdown/64-unknown-linux-gnu`. `version` is declared in the two `on_intel` blocks rather than at the top level, because on arm the URL scan already works and `brew audit` rejects a top-level version as `redundant with version scanned from URL`. The `version` variable was already passed to this template and simply unused.

**3. `version_scheme 1`.** Those bogus versions compare *greater* than any real version (`64` > `1`), so `brew upgrade` would treat `1.6.1` as a downgrade and never move existing x86_64 Linux users off the broken build.

**4. `brew style` now rejects the `shells:` argument** as `FormulaAudit/RedundantGenerateCompletionsShells`, since those are the defaults. This is what turned all 12 open release PRs on the tap red.

**5. `help2man` is commented out**, and with it the man page. `brew test-bot` only builds a bottle when every build dependency already has a bottle for the runner's exact OS. help2man publishes no Intel macOS bottle newer than `sonoma`, and the only Intel macOS runners GitHub offers are `macos-15-intel` and `macos-26-intel`, so no Intel macOS bottle for specdown could be produced at all — test-bot silently skipped the formula on those runners instead of installing it. Both pieces are left in the template inside a Jinja comment explaining the constraint, so they can be restored together once help2man ships an Intel bottle for a macOS GitHub still runs.

## Verification

Rendering this template with the v1.6.1 variables produces a formula byte-identical to the one landed in specdown/homebrew-repo#154, which passes `brew style`, `brew audit`, `brew readall --os=all --arch=all`, and a real `brew install` + `brew test` on macOS arm/intel and Linux arm/intel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)