### PR TITLE
ci: add container-tests job to run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,3 +67,10 @@ jobs:
       - name: Check markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
         if: matrix.os == 'ubuntu-latest'
+
+  container-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --features container -- --ignored


### PR DESCRIPTION
## Description

Add a new `container-tests` job to the `.github/workflows/run-tests.yml` CI workflow. This job runs the container-feature-gated tests with the `--ignored` flag.

## Changes

- Added `container-tests` job to `run-tests.yml`
- Job runs on `ubuntu-latest`
- Uses `actions/checkout@v4` for checkout
- Uses `dtolnay/rust-toolchain@stable` to install Rust
- Runs `cargo test --features container -- --ignored`
- Docker is not explicitly installed (pre-available on `ubuntu-latest` runners)

## Acceptance Criteria

- [x] New job added to the correct workflow file (`.github/workflows/run-tests.yml`)
- [x] YAML is syntactically valid (validated with `yaml.safe_load`)
- [x] Job name is exactly `container-tests`
- [x] Job runs `cargo test --features container -- --ignored`
- [x] Docker is NOT explicitly installed