### PR TITLE
ci: add container-tests job to run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,6 +45,13 @@ jobs:
           ren 'C:\Windows\System32\bash.exe' wsl-bash.exe
       - run: make test
 
+  container-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --features container -- --ignored
+
   lint:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Summary

Add a new `container-tests` job to `.github/workflows/run-tests.yml` that runs the container feature tests with `--ignored` flag.

## Changes

- Added a `container-tests` job to the existing CI workflow
- The job runs on `ubuntu-latest`
- Uses `actions/checkout@v4` for checkout
- Uses `dtolnay/rust-toolchain@stable` for Rust toolchain setup
- Runs `cargo test --features container -- --ignored`
- Docker is not explicitly installed (pre-available on `ubuntu-latest` runners)

## Test Plan

- [x] YAML syntax validated (parsed with both `yaml.safe_load` and `yq`)
- [x] No trailing whitespace
- [x] Job name is exactly `container-tests`
- [x] Indentation matches existing jobs (2-space)
- [ ] CI passes on this branch

## Context

The container executor feature (`feat: add container executor using Docker socket API`, commit 904eaa6) needs dedicated tests that run with `--ignored` since they require Docker. This job provides that coverage in the CI pipeline.