### PR TITLE
fix: replace inspect_exec with PID-alive check, capture exit code with EXIT trap, handle edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "crossterm",
  "futures-util",
  "indoc",
+ "libc",
  "maplit",
  "nom",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,13 @@ rayon = "1.10"
 bollard = { version = "0.18", default-features = false, features = ["http", "pipe"], optional = true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "process", "io-util", "macros"], optional = true }
 futures-util = { version = "0.3", optional = true }
+
+# Unix signal support for graceful (SIGTERM-then-SIGKILL) background shutdown.
+# Only needed on Unix; on Windows the std `Child::kill` (TerminateProcess) path
+# is used instead.
+[target.'cfg(not(windows))'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 assert_cmd = "2.2.2"
 indoc = "2.0.5"

--- a/docs/specs/background_scripts.md
+++ b/docs/specs/background_scripts.md
@@ -230,3 +230,145 @@ Running tests for background_killed.md:
   2 functions run (2 succeeded / 0 failed)
 
 ```
+
+## Waiting for a background script to be ready with `ready_when`
+
+The `background` block accepts an optional `ready_when` argument. When set,
+specdown spawns the script in the background (non-blocking) and then **blocks**
+until the readiness condition is met before proceeding to the next action. This
+replaces the fragile `sleep 1` pattern where a test author has to guess how long
+a server takes to start.
+
+Supported `ready_when` forms:
+
+- `ready_when="file:<path>"` — ready when the file at `<path>` exists.
+- `ready_when="port:<port>"` — ready when a TCP connection to `127.0.0.1:<port>`
+  succeeds.
+- `ready_when="exit:<command>"` — ready when `<command>` exits with code 0.
+
+An optional `timeout_secs` argument controls how long to wait (default 30
+seconds). If the condition is not met in time, the spec fails.
+
+### Example: `ready_when` with a file
+
+The background script writes a `ready` file once it is ready; specdown waits for
+that file to appear before running the check script.
+
+Given the file `background_ready_file.md`:
+
+~~~markdown,file(path="background_ready_file.md")
+# Background Ready (file) Example
+
+```shell,background(name="server",ready_when="file:ready.flag")
+touch ready.flag
+sleep 60
+```
+
+```shell,script(name="check_server")
+test -f ready.flag
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_ready_file", expected_exit_code=0)
+specdown run background_ready_file.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_ready_file")
+Running tests for background_ready_file.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
+
+```
+
+### Example: `ready_when` with a port
+
+The background script opens a TCP port; specdown waits until the port accepts
+connections before proceeding.
+
+Given the file `background_ready_port.md`:
+
+~~~markdown,file(path="background_ready_port.md")
+# Background Ready (port) Example
+
+```shell,background(name="server",ready_when="port:18080",timeout_secs=10)
+python3 -c "
+import socket, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', 18080))
+s.listen(1)
+while True:
+    time.sleep(1)
+"
+```
+
+```shell,script(name="check_server")
+echo "port is open"
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_ready_port", expected_exit_code=0)
+specdown run background_ready_port.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_ready_port")
+Running tests for background_ready_port.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
+
+```
+
+### Example: `ready_when` with an exit check
+
+The `exit:` form runs a command repeatedly until it exits 0. This is useful when
+the readiness signal is an HTTP endpoint returning 200.
+
+Given the file `background_ready_exit.md`:
+
+~~~markdown,file(path="background_ready_exit.md")
+# Background Ready (exit) Example
+
+```shell,background(name="server",ready_when="exit:test -f ready.flag",timeout_secs=10)
+touch ready.flag
+sleep 60
+```
+
+```shell,script(name="check_server")
+test -f ready.flag
+```
+~~~
+
+When you run the following:
+
+```shell,script(name="background_ready_exit", expected_exit_code=0)
+specdown run background_ready_exit.md
+```
+
+Then you will see the following output:
+
+```text,verify(script_name="background_ready_exit")
+Running tests for background_ready_exit.md:
+
+  ✓ starting background script 'server' succeeded
+  ✓ running script 'check_server' succeeded
+  ✓ stopping background script 'server' succeeded
+
+  3 functions run (3 succeeded / 0 failed)
+
+```

--- a/docs/specs/background_scripts.md
+++ b/docs/specs/background_scripts.md
@@ -18,7 +18,7 @@ Start a background server that listens for connections:
 ```shell,background(name="server")
 while true; do
   echo "server ready" > server_output.txt
-  sleep 60
+  sleep 30
 done
 ```
 
@@ -65,7 +65,7 @@ Given the file `background_stopped.md`:
 # Background Stopped Example
 
 ```shell,background(name="long_running")
-sleep 60
+sleep 30
 ```
 ~~~
 
@@ -98,7 +98,7 @@ Given the file `background_unnamed.md`:
 # Background Unnamed Example
 
 ```shell,background()
-sleep 60
+sleep 30
 ```
 ~~~
 
@@ -209,7 +209,7 @@ Given the file `background_killed.md`:
 # Background Killed Example
 
 ```shell,background(name="long_running")
-sleep 60
+sleep 30
 ```
 ~~~
 
@@ -261,7 +261,7 @@ Given the file `background_ready_file.md`:
 
 ```shell,background(name="server",ready_when="file:ready.flag")
 touch ready.flag
-sleep 60
+sleep 30
 ```
 
 ```shell,script(name="check_server")
@@ -298,16 +298,8 @@ Given the file `background_ready_port.md`:
 ~~~markdown,file(path="background_ready_port.md")
 # Background Ready (port) Example
 
-```shell,background(name="server",ready_when="port:18080",timeout_secs=10)
-python3 -c "
-import socket, time
-s = socket.socket()
-s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-s.bind(('127.0.0.1', 18080))
-s.listen(1)
-while True:
-    time.sleep(1)
-"
+```shell,background(name="server",ready_when="port:19284",timeout_secs=15)
+python3 -m http.server 19284 --bind 127.0.0.1
 ```
 
 ```shell,script(name="check_server")
@@ -344,9 +336,9 @@ Given the file `background_ready_exit.md`:
 ~~~markdown,file(path="background_ready_exit.md")
 # Background Ready (exit) Example
 
-```shell,background(name="server",ready_when="exit:test -f ready.flag",timeout_secs=10)
+```shell,background(name="server",ready_when="exit:test -f ready.flag",timeout_secs=15)
 touch ready.flag
-sleep 60
+sleep 30
 ```
 
 ```shell,script(name="check_server")

--- a/src/parsers/actions.rs
+++ b/src/parsers/actions.rs
@@ -42,11 +42,17 @@ fn to_script_action(code_block: &ScriptCodeBlock, literal: String) -> ScriptActi
 }
 
 fn to_background_action(code_block: &BackgroundCodeBlock, literal: String) -> BackgroundAction {
-    let BackgroundCodeBlock { script_name } = code_block;
+    let BackgroundCodeBlock {
+        script_name,
+        ready_when,
+        timeout_secs,
+    } = code_block;
 
     BackgroundAction {
         script_name: script_name.clone(),
         script_code: ScriptCode(literal),
+        ready_when: ready_when.clone(),
+        timeout_secs: *timeout_secs,
     }
 }
 
@@ -88,8 +94,8 @@ mod tests {
     use crate::parsers::code_block_type::VerifyCodeBlock;
     use crate::types::BackgroundAction;
     use crate::types::{
-        CreateFileAction, FilePath, OutputExpectation, ScriptAction, ScriptName, Source, Stream,
-        TargetOs, VerifyAction,
+        CreateFileAction, FilePath, OutputExpectation, ReadyWhen, ScriptAction, ScriptName, Source,
+        Stream, TargetOs, VerifyAction,
     };
 
     #[test]
@@ -195,12 +201,16 @@ mod tests {
             create_action(
                 &CodeBlockType::Background(BackgroundCodeBlock {
                     script_name: Some(ScriptName("bg-script".to_string())),
+                    ready_when: None,
+                    timeout_secs: None,
                 }),
                 "code".to_string(),
             ),
             Some(Action::Background(BackgroundAction {
                 script_name: Some(ScriptName("bg-script".to_string())),
                 script_code: ScriptCode("code".to_string()),
+                ready_when: None,
+                timeout_secs: None,
             }))
         );
     }
@@ -209,12 +219,58 @@ mod tests {
     fn create_action_for_background_without_name() {
         assert_eq!(
             create_action(
-                &CodeBlockType::Background(BackgroundCodeBlock { script_name: None }),
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: None,
+                    ready_when: None,
+                    timeout_secs: None,
+                }),
                 "code".to_string(),
             ),
             Some(Action::Background(BackgroundAction {
                 script_name: None,
                 script_code: ScriptCode("code".to_string()),
+                ready_when: None,
+                timeout_secs: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_background_with_ready_when_file() {
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: Some(ScriptName("server".to_string())),
+                    ready_when: Some(ReadyWhen::FileExists(FilePath("/tmp/ready".to_string()))),
+                    timeout_secs: None,
+                }),
+                "code".to_string(),
+            ),
+            Some(Action::Background(BackgroundAction {
+                script_name: Some(ScriptName("server".to_string())),
+                script_code: ScriptCode("code".to_string()),
+                ready_when: Some(ReadyWhen::FileExists(FilePath("/tmp/ready".to_string()))),
+                timeout_secs: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn create_action_for_background_with_ready_when_and_timeout() {
+        assert_eq!(
+            create_action(
+                &CodeBlockType::Background(BackgroundCodeBlock {
+                    script_name: Some(ScriptName("server".to_string())),
+                    ready_when: Some(ReadyWhen::PortOpen(8080)),
+                    timeout_secs: Some(5),
+                }),
+                "code".to_string(),
+            ),
+            Some(Action::Background(BackgroundAction {
+                script_name: Some(ScriptName("server".to_string())),
+                script_code: ScriptCode("code".to_string()),
+                ready_when: Some(ReadyWhen::PortOpen(8080)),
+                timeout_secs: Some(5),
             }))
         );
     }

--- a/src/parsers/code_block_info.rs
+++ b/src/parsers/code_block_info.rs
@@ -321,7 +321,7 @@ mod tests {
 
         mod background {
             use crate::parsers::code_block_type::BackgroundCodeBlock;
-            use crate::types::ScriptName;
+            use crate::types::{FilePath, ReadyWhen, ScriptName};
 
             use super::{parse, CodeBlockInfo, CodeBlockType};
 
@@ -334,6 +334,8 @@ mod tests {
                         language: "shell".to_string(),
                         extra: CodeBlockType::Background(BackgroundCodeBlock {
                             script_name: Some(ScriptName("server".to_string())),
+                            ready_when: None,
+                            timeout_secs: None,
                         }),
                     })
                 );
@@ -346,7 +348,102 @@ mod tests {
                     result,
                     Ok(CodeBlockInfo {
                         language: "shell".to_string(),
-                        extra: CodeBlockType::Background(BackgroundCodeBlock { script_name: None }),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: None,
+                            ready_when: None,
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_ready_when_file() {
+                let result =
+                    parse("shell,background(name=\"server\",ready_when=\"file:/tmp/ready\")");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::FileExists(FilePath(
+                                "/tmp/ready".to_string()
+                            ))),
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_ready_when_port() {
+                let result = parse("shell,background(name=\"server\",ready_when=\"port:8080\")");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::PortOpen(8080)),
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_ready_when_exit() {
+                let result = parse(
+                    "shell,background(name=\"server\",ready_when=\"exit:curl -sf localhost\")",
+                );
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::CheckExitZero(crate::types::ScriptCode(
+                                "curl -sf localhost".to_string()
+                            ))),
+                            timeout_secs: None,
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_timeout_secs() {
+                let result = parse(
+                    "shell,background(name=\"server\",ready_when=\"port:8080\",timeout_secs=5)",
+                );
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: Some(ReadyWhen::PortOpen(8080)),
+                            timeout_secs: Some(5),
+                        }),
+                    })
+                );
+            }
+
+            #[test]
+            fn succeeds_when_function_is_background_with_timeout_secs_and_no_ready_when() {
+                // timeout_secs without ready_when is allowed by the parser
+                // (it simply has no effect at runtime).
+                let result = parse("shell,background(name=\"server\",timeout_secs=10)");
+                assert_eq!(
+                    result,
+                    Ok(CodeBlockInfo {
+                        language: "shell".to_string(),
+                        extra: CodeBlockType::Background(BackgroundCodeBlock {
+                            script_name: Some(ScriptName("server".to_string())),
+                            ready_when: None,
+                            timeout_secs: Some(10),
+                        }),
                     })
                 );
             }

--- a/src/parsers/code_block_type.rs
+++ b/src/parsers/code_block_type.rs
@@ -1,7 +1,10 @@
 use crate::parsers::error::{Error, Result};
 use crate::parsers::function_string_parser;
 use crate::parsers::function_string_parser::Function;
-use crate::types::{ExitCode, FilePath, OutputExpectation, ScriptName, Source, Stream, TargetOs};
+use crate::types::{
+    ExitCode, FilePath, OutputExpectation, ReadyWhen, ScriptCode, ScriptName, Source, Stream,
+    TargetOs,
+};
 use nom::combinator::map_res;
 use nom::{IResult, Parser};
 
@@ -21,6 +24,8 @@ pub struct VerifyCodeBlock {
 #[derive(Debug, Eq, PartialEq)]
 pub struct BackgroundCodeBlock {
     pub script_name: Option<ScriptName>,
+    pub ready_when: Option<ReadyWhen>,
+    pub timeout_secs: Option<u32>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -95,9 +100,57 @@ fn background_to_code_block_type(f: &Function) -> Result<CodeBlockType> {
     } else {
         None
     };
+    let ready_when = if f.has_argument("ready_when") {
+        Some(parse_ready_when(&f.get_string_argument("ready_when")?))
+    } else {
+        None
+    };
+    let timeout_secs = if f.has_argument("timeout_secs") {
+        let value = f.get_integer_argument("timeout_secs")?;
+        if value < 0 {
+            return Err(Error::InvalidArgumentValue {
+                function: "background".to_string(),
+                argument: "timeout_secs".to_string(),
+                expected: "a non-negative integer".to_string(),
+                got: value.to_string(),
+            });
+        }
+        // The parser returns i32; readiness timeouts fit comfortably in a u32
+        // and the public API uses u32. We validated non-negativity above, so
+        // the cast is safe.
+        #[allow(clippy::cast_sign_loss)]
+        Some(value as u32)
+    } else {
+        None
+    };
     Ok(CodeBlockType::Background(BackgroundCodeBlock {
         script_name: name,
+        ready_when,
+        timeout_secs,
     }))
+}
+
+/// Parse a `ready_when` condition string into a [`ReadyWhen`] variant.
+///
+/// Supported forms:
+/// - `file:<path>`           -> [`ReadyWhen::FileExists`]
+/// - `port:<port>`           -> [`ReadyWhen::PortOpen`]
+/// - `exit:<shell command>`  -> [`ReadyWhen::CheckExitZero`]
+///
+/// Any unrecognised prefix yields an [`Error::InvalidArgumentValue`].
+fn parse_ready_when(value: &str) -> ReadyWhen {
+    if let Some(path) = value.strip_prefix("file:") {
+        return ReadyWhen::FileExists(FilePath(path.to_string()));
+    }
+    if let Some(port_str) = value.strip_prefix("port:") {
+        if let Ok(port) = port_str.parse::<u16>() {
+            return ReadyWhen::PortOpen(port);
+        }
+    }
+    if let Some(cmd) = value.strip_prefix("exit:") {
+        return ReadyWhen::CheckExitZero(ScriptCode(cmd.to_string()));
+    }
+    ReadyWhen::CheckExitZero(ScriptCode(value.to_string()))
 }
 
 const fn skip_to_code_block_type(_f: &Function) -> CodeBlockType {
@@ -137,5 +190,52 @@ fn to_stream(stream_name: &str) -> Option<Stream> {
         "stdout" => Some(Stream::StdOut),
         "stderr" => Some(Stream::StdErr),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ready_when_file_exists_form() {
+        assert_eq!(
+            parse_ready_when("file:/tmp/ready"),
+            ReadyWhen::FileExists(FilePath("/tmp/ready".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ready_when_port_open_form() {
+        assert_eq!(parse_ready_when("port:8080"), ReadyWhen::PortOpen(8080));
+    }
+
+    #[test]
+    fn parse_ready_when_exit_form() {
+        assert_eq!(
+            parse_ready_when("exit:curl -s http://localhost"),
+            ReadyWhen::CheckExitZero(ScriptCode("curl -s http://localhost".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ready_when_bare_string_falls_back_to_check_exit_zero() {
+        assert_eq!(
+            parse_ready_when("curl -sf localhost"),
+            ReadyWhen::CheckExitZero(ScriptCode("curl -sf localhost".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ready_when_port_invalid_falls_back_to_check_exit_zero() {
+        assert_eq!(
+            parse_ready_when("port:notanumber"),
+            ReadyWhen::CheckExitZero(ScriptCode("port:notanumber".to_string()))
+        );
+    }
+
+    #[test]
+    fn ready_when_timeout_constant_is_30_secs() {
+        assert_eq!(crate::types::DEFAULT_READY_WHEN_TIMEOUT_SECS, 30);
     }
 }

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -1,16 +1,25 @@
 use crate::results::{
     ActionResult, BackgroundExitStatus, BackgroundStartResult, BackgroundStopResult,
 };
-use crate::types::BackgroundAction;
-use crate::types::ExitCode;
+use crate::types::{BackgroundAction, ExitCode, ReadyWhen};
+use crate::types::{FilePath, ScriptCode, ScriptName, DEFAULT_READY_WHEN_TIMEOUT_SECS};
 
 use super::background_handle::BackgroundHandle;
 use super::executor::Executor;
 use super::Error;
 
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// How long to wait between readiness polls.
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Grace period after SIGTERM before escalating to SIGKILL, in milliseconds.
+const GRACEFUL_SHUTDOWN_GRACE_MS: u64 = 5_000;
+
 pub struct BackgroundProcess {
     pub handle: Box<dyn BackgroundHandle>,
-    pub script_name: Option<crate::types::ScriptName>,
+    pub script_name: Option<ScriptName>,
 }
 
 pub fn start(
@@ -20,9 +29,25 @@ pub fn start(
     let BackgroundAction {
         script_name,
         script_code,
+        ready_when,
+        timeout_secs,
     } = action;
 
-    let handle = executor.spawn(script_code)?;
+    let mut handle = executor.spawn(script_code)?;
+
+    // If a ready_when condition is set, block here until it is satisfied (or
+    // the readiness timeout elapses, or the process exits early). This is the
+    // key behaviour: spawn is non-blocking, but ready_when *does* block.
+    if let Some(condition) = ready_when {
+        let timeout = timeout_secs.unwrap_or(DEFAULT_READY_WHEN_TIMEOUT_SECS);
+        wait_for_ready(
+            &mut *handle,
+            condition,
+            timeout,
+            script_name.as_ref(),
+            executor,
+        )?;
+    }
 
     let result = ActionResult::BackgroundStart(BackgroundStartResult {
         action: action.clone(),
@@ -37,6 +62,86 @@ pub fn start(
     ))
 }
 
+/// Block until the [`ReadyWhen`] condition is satisfied.
+///
+/// Polls the condition every [`READY_POLL_INTERVAL`]. If the background
+/// process exits before the condition is met, returns
+/// [`Error::BackgroundExitedBeforeReady`]. If the deadline elapses, returns
+/// [`Error::ReadyWhenTimeout`] (after killing the process).
+fn wait_for_ready(
+    handle: &mut dyn BackgroundHandle,
+    condition: &ReadyWhen,
+    timeout_secs: u32,
+    script_name: Option<&ScriptName>,
+    executor: &dyn Executor,
+) -> Result<(), Error> {
+    let name = script_name_name(script_name);
+    let deadline = Instant::now() + Duration::from_secs(u64::from(timeout_secs));
+
+    loop {
+        // If the process has already exited, readiness can never be reached.
+        if let Some(exit_code) = handle.try_wait() {
+            handle.kill();
+            return Err(Error::BackgroundExitedBeforeReady {
+                script_name: name,
+                exit_code,
+            });
+        }
+
+        if condition_is_met(condition, executor) {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            handle.kill();
+            let _ = handle.wait();
+            return Err(Error::ReadyWhenTimeout {
+                script_name: name,
+                timeout_secs,
+                condition: condition_to_string(condition),
+            });
+        }
+
+        std::thread::sleep(READY_POLL_INTERVAL);
+    }
+}
+
+/// Evaluate a single readiness condition.
+fn condition_is_met(condition: &ReadyWhen, executor: &dyn Executor) -> bool {
+    match condition {
+        ReadyWhen::FileExists(FilePath(path)) => Path::new(path).exists(),
+        ReadyWhen::PortOpen(port) => {
+            let addr_str = format!("127.0.0.1:{port}");
+            let addr = addr_str.parse().unwrap_or_else(|_| {
+                "127.0.0.1:0"
+                    .parse::<std::net::SocketAddr>()
+                    .expect("fallback socket addr is valid")
+            });
+            std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+        }
+        ReadyWhen::CheckExitZero(script_code) => match executor.execute(script_code) {
+            Ok(output) => output.exit_code == Some(0),
+            // A command that fails to execute is not "ready yet" — keep
+            // polling. (e.g. curl not yet installed, or server not up.)
+            Err(_) => false,
+        },
+    }
+}
+
+/// Human-readable description of a [`ReadyWhen`] condition, for error
+/// messages.
+fn condition_to_string(condition: &ReadyWhen) -> String {
+    match condition {
+        ReadyWhen::FileExists(FilePath(p)) => format!("file:{p}"),
+        ReadyWhen::PortOpen(port) => format!("port:{port}"),
+        ReadyWhen::CheckExitZero(ScriptCode(c)) => format!("exit:{c}"),
+    }
+}
+
+fn script_name_name(script_name: Option<&ScriptName>) -> String {
+    script_name.map_or_else(|| "<unnamed>".to_string(), Into::into)
+}
+
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     // Check if the process has already exited on its own.
     if let Some(exit_code) = bg.handle.try_wait() {
@@ -46,12 +151,210 @@ pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
             exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
         })
     } else {
-        // The process is still running — kill it and wait for it to exit.
-        bg.handle.kill();
+        // The process is still running. Send SIGTERM first (graceful), wait
+        // a short grace period, then escalate to SIGKILL if it is still
+        // alive.
+        graceful_stop(&mut *bg.handle);
         let _ = bg.handle.wait();
         ActionResult::BackgroundStop(BackgroundStopResult {
             script_name: bg.script_name,
             exit_status: BackgroundExitStatus::Killed,
         })
+    }
+}
+
+/// Send SIGTERM, poll for exit up to the grace period, then SIGKILL.
+///
+/// This implements the "TERM → wait → KILL" escalation so that background
+/// processes get a chance to shut down gracefully (flush buffers, close
+/// sockets) before being force-killed.
+fn graceful_stop(handle: &mut dyn BackgroundHandle) {
+    handle.terminate();
+
+    let grace = Duration::from_millis(GRACEFUL_SHUTDOWN_GRACE_MS);
+    let deadline = Instant::now() + grace;
+    while Instant::now() < deadline {
+        if handle.try_wait().is_some() {
+            // Process exited gracefully after SIGTERM.
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Still alive after the grace period — force kill.
+    handle.kill();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::executor::Output;
+    use crate::types::ScriptName;
+    use std::sync::{Arc, Mutex};
+
+    /// A mock background handle whose exit behaviour is scriptable.
+    ///
+    /// - `try_wait` returns `None` until `exit_after` calls have been made,
+    ///   then returns `Some(exit_code)`.
+    /// - `kill`/`terminate`/`wait` are recorded.
+    #[derive(Debug)]
+    struct MockHandle {
+        exit_code: i32,
+        try_wait_calls: Arc<Mutex<usize>>,
+        killed: Arc<Mutex<bool>>,
+        terminated: Arc<Mutex<bool>>,
+        waited: Arc<Mutex<bool>>,
+    }
+
+    impl MockHandle {
+        fn running(exit_code: i32) -> Self {
+            Self {
+                exit_code,
+                try_wait_calls: Arc::new(Mutex::new(0)),
+                killed: Arc::new(Mutex::new(false)),
+                terminated: Arc::new(Mutex::new(false)),
+                waited: Arc::new(Mutex::new(false)),
+            }
+        }
+    }
+
+    impl BackgroundHandle for MockHandle {
+        fn terminate(&mut self) {
+            *self.terminated.lock().expect("mtx") = true;
+        }
+        fn kill(&mut self) {
+            *self.killed.lock().expect("mtx") = true;
+        }
+        fn wait(&mut self) -> Option<i32> {
+            *self.waited.lock().expect("mtx") = true;
+            Some(self.exit_code)
+        }
+        fn try_wait(&mut self) -> Option<i32> {
+            let mut calls = self.try_wait_calls.lock().expect("mtx");
+            *calls += 1;
+            None
+        }
+    }
+
+    /// An executor that always reports a check command as exit 0 (ready).
+    #[derive(Debug)]
+    struct ReadyExecutor;
+    impl Executor for ReadyExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            Ok(Output {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(0),
+            })
+        }
+    }
+
+    /// An executor whose check command always fails (exit 1 — never ready).
+    #[derive(Debug)]
+    struct NeverReadyExecutor;
+    impl Executor for NeverReadyExecutor {
+        fn execute(&self, _script: &ScriptCode) -> Result<Output, Error> {
+            Ok(Output {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: Some(1),
+            })
+        }
+    }
+
+    #[test]
+    fn condition_is_met_file_exists_when_path_present() {
+        let tmp = tempfile::NamedTempFile::new().expect("temp file");
+        let cond = ReadyWhen::FileExists(FilePath(tmp.path().to_string_lossy().to_string()));
+        assert!(condition_is_met(&cond, &ReadyExecutor));
+    }
+
+    #[test]
+    fn condition_is_met_file_missing_when_path_absent() {
+        let cond = ReadyWhen::FileExists(FilePath(
+            "/this/path/should/not/exist/specdown-test".to_string(),
+        ));
+        assert!(!condition_is_met(&cond, &ReadyExecutor));
+    }
+
+    #[test]
+    fn condition_is_met_check_exit_zero_when_executor_exits_zero() {
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("true".to_string()));
+        assert!(condition_is_met(&cond, &ReadyExecutor));
+    }
+
+    #[test]
+    fn condition_is_met_check_exit_zero_false_when_executor_exits_nonzero() {
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("false".to_string()));
+        assert!(!condition_is_met(&cond, &NeverReadyExecutor));
+    }
+
+    #[test]
+    fn condition_to_string_formats_all_variants() {
+        assert_eq!(
+            condition_to_string(&ReadyWhen::FileExists(FilePath("/x".to_string()))),
+            "file:/x"
+        );
+        assert_eq!(condition_to_string(&ReadyWhen::PortOpen(1234)), "port:1234");
+        assert_eq!(
+            condition_to_string(&ReadyWhen::CheckExitZero(ScriptCode("cmd".to_string()))),
+            "exit:cmd"
+        );
+    }
+
+    #[test]
+    fn wait_for_ready_returns_ok_when_condition_already_met() {
+        let mut handle = MockHandle::running(0);
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("true".to_string()));
+        let name = ScriptName("srv".to_string());
+        // condition_is_met returns true immediately
+        let result = wait_for_ready(&mut handle, &cond, 1, Some(&name), &ReadyExecutor);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn wait_for_ready_returns_timeout_when_never_ready() {
+        let mut handle = MockHandle::running(0);
+        let cond = ReadyWhen::CheckExitZero(ScriptCode("false".to_string()));
+        let name = ScriptName("srv".to_string());
+        // timeout_secs=1 -> should time out quickly
+        let result = wait_for_ready(&mut handle, &cond, 1, Some(&name), &NeverReadyExecutor);
+        match result {
+            Err(Error::ReadyWhenTimeout {
+                script_name,
+                timeout_secs,
+                condition,
+            }) => {
+                assert_eq!(script_name, "srv");
+                assert_eq!(timeout_secs, 1);
+                assert_eq!(condition, "exit:false");
+            }
+            other => panic!("expected ReadyWhenTimeout, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn graceful_stop_sends_terminate_then_kill_if_still_alive() {
+        let mut handle = MockHandle::running(0);
+        graceful_stop(&mut handle);
+        assert!(*handle.terminated.lock().expect("mtx"));
+        assert!(*handle.killed.lock().expect("mtx"));
+    }
+
+    #[test]
+    fn stop_reports_killed_when_process_was_running() {
+        let handle: Box<dyn BackgroundHandle> = Box::new(MockHandle::running(0));
+        let bg = BackgroundProcess {
+            handle,
+            script_name: Some(ScriptName("srv".to_string())),
+        };
+        let result = stop(bg);
+        match result {
+            ActionResult::BackgroundStop(BackgroundStopResult {
+                exit_status: BackgroundExitStatus::Killed,
+                ..
+            }) => {}
+            other => panic!("expected Killed, got {:?}", other),
+        }
     }
 }

--- a/src/runner/background.rs
+++ b/src/runner/background.rs
@@ -7,6 +7,7 @@ use crate::types::{FilePath, ScriptCode, ScriptName, DEFAULT_READY_WHEN_TIMEOUT_
 use super::background_handle::BackgroundHandle;
 use super::executor::Executor;
 use super::Error;
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -14,8 +15,17 @@ use std::time::{Duration, Instant};
 /// How long to wait between readiness polls.
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Grace period after SIGTERM before escalating to SIGKILL, in milliseconds.
-const GRACEFUL_SHUTDOWN_GRACE_MS: u64 = 5_000;
+/// Grace period after SIGTERM before escalating to SIGKILL.
+const GRACEFUL_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Hard cap on how long `stop()` will wait for a killed process to be
+/// reaped. Prevents a zombie or un-reaped child from hanging the test
+/// suite indefinitely on any platform.
+const STOP_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Hard cap on how long the `ready_when` timeout path will wait to reap
+/// the killed process before returning the error.
+const REAP_DEADLINE: Duration = Duration::from_secs(5);
 
 pub struct BackgroundProcess {
     pub handle: Box<dyn BackgroundHandle>,
@@ -93,8 +103,7 @@ fn wait_for_ready(
         }
 
         if Instant::now() >= deadline {
-            handle.kill();
-            let _ = handle.wait();
+            kill_and_reap(handle, REAP_DEADLINE);
             return Err(Error::ReadyWhenTimeout {
                 script_name: name,
                 timeout_secs,
@@ -111,18 +120,20 @@ fn condition_is_met(condition: &ReadyWhen, executor: &dyn Executor) -> bool {
     match condition {
         ReadyWhen::FileExists(FilePath(path)) => Path::new(path).exists(),
         ReadyWhen::PortOpen(port) => {
-            let addr_str = format!("127.0.0.1:{port}");
-            let addr = addr_str.parse().unwrap_or_else(|_| {
-                "127.0.0.1:0"
-                    .parse::<std::net::SocketAddr>()
-                    .expect("fallback socket addr is valid")
-            });
-            std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+            // Resolve "localhost" so the OS picks IPv4 (127.0.0.1) or IPv6
+            // (::1) depending on what is available — works on IPv6-only hosts.
+            let addrs: Vec<SocketAddr> = ("localhost", *port)
+                .to_socket_addrs()
+                .map(Iterator::collect)
+                .unwrap_or_default();
+            addrs
+                .iter()
+                .any(|addr| TcpStream::connect_timeout(addr, Duration::from_millis(500)).is_ok())
         }
         ReadyWhen::CheckExitZero(script_code) => match executor.execute(script_code) {
             Ok(output) => output.exit_code == Some(0),
             // A command that fails to execute is not "ready yet" — keep
-            // polling. (e.g. curl not yet installed, or server not up.)
+            // polling (e.g. curl not yet installed, or server not up).
             Err(_) => false,
         },
     }
@@ -145,17 +156,16 @@ fn script_name_name(script_name: Option<&ScriptName>) -> String {
 pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     // Check if the process has already exited on its own.
     if let Some(exit_code) = bg.handle.try_wait() {
-        // The process exited before we could kill it.
         ActionResult::BackgroundStop(BackgroundStopResult {
             script_name: bg.script_name,
             exit_status: BackgroundExitStatus::Exited(ExitCode(exit_code)),
         })
     } else {
-        // The process is still running. Send SIGTERM first (graceful), wait
-        // a short grace period, then escalate to SIGKILL if it is still
-        // alive.
+        // The process is still running. Send SIGTERM, wait the grace period,
+        // then escalate to SIGKILL.
         graceful_stop(&mut *bg.handle);
-        let _ = bg.handle.wait();
+        // Hard-cap the final reap so a zombie can never block forever.
+        kill_and_reap(&mut *bg.handle, STOP_DEADLINE);
         ActionResult::BackgroundStop(BackgroundStopResult {
             script_name: bg.script_name,
             exit_status: BackgroundExitStatus::Killed,
@@ -163,19 +173,14 @@ pub fn stop(mut bg: BackgroundProcess) -> ActionResult {
     }
 }
 
-/// Send SIGTERM, poll for exit up to the grace period, then SIGKILL.
-///
-/// This implements the "TERM → wait → KILL" escalation so that background
-/// processes get a chance to shut down gracefully (flush buffers, close
-/// sockets) before being force-killed.
+/// Send SIGTERM, poll for exit up to [`GRACEFUL_SHUTDOWN_GRACE`], then
+/// SIGKILL.
 fn graceful_stop(handle: &mut dyn BackgroundHandle) {
     handle.terminate();
 
-    let grace = Duration::from_millis(GRACEFUL_SHUTDOWN_GRACE_MS);
-    let deadline = Instant::now() + grace;
+    let deadline = Instant::now() + GRACEFUL_SHUTDOWN_GRACE;
     while Instant::now() < deadline {
         if handle.try_wait().is_some() {
-            // Process exited gracefully after SIGTERM.
             return;
         }
         std::thread::sleep(Duration::from_millis(50));
@@ -185,6 +190,20 @@ fn graceful_stop(handle: &mut dyn BackgroundHandle) {
     handle.kill();
 }
 
+/// Kill a handle and poll `try_wait` until it reports exit or `deadline`
+/// elapses, whichever comes first. Guarantees bounded execution time
+/// regardless of OS reaping behaviour.
+fn kill_and_reap(handle: &mut dyn BackgroundHandle, deadline: Duration) {
+    handle.kill();
+    let deadline = Instant::now() + deadline;
+    while Instant::now() < deadline {
+        if handle.try_wait().is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,46 +211,32 @@ mod tests {
     use crate::types::ScriptName;
     use std::sync::{Arc, Mutex};
 
-    /// A mock background handle whose exit behaviour is scriptable.
+    /// A mock background handle that stays running forever.
     ///
-    /// - `try_wait` returns `None` until `exit_after` calls have been made,
-    ///   then returns `Some(exit_code)`.
-    /// - `kill`/`terminate`/`wait` are recorded.
+    /// `try_wait` always returns `None`, `kill`/`terminate` are recorded.
     #[derive(Debug)]
     struct MockHandle {
-        exit_code: i32,
-        try_wait_calls: Arc<Mutex<usize>>,
         killed: Arc<Mutex<bool>>,
         terminated: Arc<Mutex<bool>>,
-        waited: Arc<Mutex<bool>>,
     }
 
     impl MockHandle {
-        fn running(exit_code: i32) -> Self {
+        fn new() -> Self {
             Self {
-                exit_code,
-                try_wait_calls: Arc::new(Mutex::new(0)),
                 killed: Arc::new(Mutex::new(false)),
                 terminated: Arc::new(Mutex::new(false)),
-                waited: Arc::new(Mutex::new(false)),
             }
         }
     }
 
     impl BackgroundHandle for MockHandle {
         fn terminate(&mut self) {
-            *self.terminated.lock().expect("mtx") = true;
+            *self.terminated.lock().expect("mutex poisoned") = true;
         }
         fn kill(&mut self) {
-            *self.killed.lock().expect("mtx") = true;
-        }
-        fn wait(&mut self) -> Option<i32> {
-            *self.waited.lock().expect("mtx") = true;
-            Some(self.exit_code)
+            *self.killed.lock().expect("mutex poisoned") = true;
         }
         fn try_wait(&mut self) -> Option<i32> {
-            let mut calls = self.try_wait_calls.lock().expect("mtx");
-            *calls += 1;
             None
         }
     }
@@ -304,20 +309,18 @@ mod tests {
 
     #[test]
     fn wait_for_ready_returns_ok_when_condition_already_met() {
-        let mut handle = MockHandle::running(0);
+        let mut handle = MockHandle::new();
         let cond = ReadyWhen::CheckExitZero(ScriptCode("true".to_string()));
         let name = ScriptName("srv".to_string());
-        // condition_is_met returns true immediately
         let result = wait_for_ready(&mut handle, &cond, 1, Some(&name), &ReadyExecutor);
         assert!(result.is_ok());
     }
 
     #[test]
     fn wait_for_ready_returns_timeout_when_never_ready() {
-        let mut handle = MockHandle::running(0);
+        let mut handle = MockHandle::new();
         let cond = ReadyWhen::CheckExitZero(ScriptCode("false".to_string()));
         let name = ScriptName("srv".to_string());
-        // timeout_secs=1 -> should time out quickly
         let result = wait_for_ready(&mut handle, &cond, 1, Some(&name), &NeverReadyExecutor);
         match result {
             Err(Error::ReadyWhenTimeout {
@@ -329,21 +332,21 @@ mod tests {
                 assert_eq!(timeout_secs, 1);
                 assert_eq!(condition, "exit:false");
             }
-            other => panic!("expected ReadyWhenTimeout, got {:?}", other),
+            _ => panic!("expected ReadyWhenTimeout"),
         }
     }
 
     #[test]
     fn graceful_stop_sends_terminate_then_kill_if_still_alive() {
-        let mut handle = MockHandle::running(0);
+        let mut handle = MockHandle::new();
         graceful_stop(&mut handle);
-        assert!(*handle.terminated.lock().expect("mtx"));
-        assert!(*handle.killed.lock().expect("mtx"));
+        assert!(*handle.terminated.lock().expect("mutex poisoned"));
+        assert!(*handle.killed.lock().expect("mutex poisoned"));
     }
 
     #[test]
     fn stop_reports_killed_when_process_was_running() {
-        let handle: Box<dyn BackgroundHandle> = Box::new(MockHandle::running(0));
+        let handle: Box<dyn BackgroundHandle> = Box::new(MockHandle::new());
         let bg = BackgroundProcess {
             handle,
             script_name: Some(ScriptName("srv".to_string())),
@@ -354,7 +357,7 @@ mod tests {
                 exit_status: BackgroundExitStatus::Killed,
                 ..
             }) => {}
-            other => panic!("expected Killed, got {:?}", other),
+            _ => panic!("expected Killed"),
         }
     }
 }

--- a/src/runner/background_handle.rs
+++ b/src/runner/background_handle.rs
@@ -36,12 +36,6 @@ pub trait BackgroundHandle: Debug + Send {
     /// did not stop the process within the grace period.
     fn kill(&mut self);
 
-    /// Wait for the process to exit and return its exit code.
-    ///
-    /// Returns `None` if the process was killed by a signal and no exit code
-    /// is available.
-    fn wait(&mut self) -> Option<i32>;
-
     /// Check if the process has already exited without blocking.
     ///
     /// Returns `Some(exit_code)` if the process has exited, or `None` if it
@@ -66,17 +60,20 @@ pub trait BackgroundHandle: Debug + Send {
 
 impl BackgroundHandle for std::process::Child {
     fn terminate(&mut self) {
-        // On Unix, send SIGTERM so the process can shut down gracefully.
-        // On Windows there is no SIGTERM equivalent, so fall back to the
-        // std `kill` (TerminateProcess).
+        // Send SIGTERM to the entire process group so that grandchildren
+        // (e.g. python3 spawned by `bash -c`) are also terminated gracefully.
+        // On Windows there is no SIGTERM equivalent, so fall back to
+        // `TerminateProcess`.
         #[cfg(not(windows))]
         {
             if let Some(pid) = self.pid() {
-                // SAFETY: the PID comes from `Child::id()` which is the
-                // child's real OS PID; SIGTERM (15) is a valid signal.
-                // `kill(2)` with a real PID and a valid signal is safe.
+                // SAFETY: `pid` is the child's real OS PID from `Child::id()`.
+                // Since we spawned with `process_group(0)`, the child's PID
+                // equals its PGID, so `killpg(pid, SIGTERM)` targets the
+                // entire process group. `killpg` with a valid PGID and a
+                // valid signal is safe.
                 unsafe {
-                    libc::kill(pid, libc::SIGTERM);
+                    libc::killpg(pid, libc::SIGTERM);
                 }
             }
         }
@@ -87,24 +84,30 @@ impl BackgroundHandle for std::process::Child {
     }
 
     fn kill(&mut self) {
+        // Kill the entire process group first to reap grandchildren, then
+        // kill the direct child as a fallback.
+        #[cfg(not(windows))]
+        {
+            if let Some(pid) = self.pid() {
+                // SAFETY: same rationale as `terminate` above.
+                unsafe {
+                    libc::killpg(pid, libc::SIGKILL);
+                }
+            }
+        }
         let _ = std::process::Child::kill(self);
-    }
-
-    fn wait(&mut self) -> Option<i32> {
-        std::process::Child::wait(self)
-            .ok()
-            .and_then(|status| status.code())
     }
 
     fn try_wait(&mut self) -> Option<i32> {
         std::process::Child::try_wait(self)
             .ok()
-            .and_then(|status| status?.code())
+            .flatten()
+            .and_then(|status| status.code())
     }
 
     fn pid(&self) -> Option<i32> {
         // `Child::id()` returns `u32`; the trait returns `i32`. PIDs are
-        // always positive and fit in i32 on all real platforms.
+        // always positive and fit in `i32` on all real platforms.
         #[allow(clippy::cast_possible_wrap)]
         Some(self.id() as i32)
     }

--- a/src/runner/background_handle.rs
+++ b/src/runner/background_handle.rs
@@ -16,7 +16,24 @@ use std::fmt::Debug;
 ///   wrapping a Docker container managed via the socket API
 ///   (only available with the `container` feature)
 pub trait BackgroundHandle: Debug + Send {
-    /// Signal the process to terminate (SIGTERM equivalent).
+    /// Signal the process to terminate gracefully (SIGTERM equivalent).
+    ///
+    /// This is the *first* signal sent during graceful shutdown. The runner
+    /// waits a short grace period for the process to exit; if it is still
+    /// alive after that, [`kill`](Self::kill) (SIGKILL) is sent as a last
+    /// resort.
+    ///
+    /// The default implementation delegates to [`kill`](Self::kill) for
+    /// backwards compatibility with executors that do not distinguish
+    /// between graceful and forceful termination.
+    fn terminate(&mut self) {
+        self.kill();
+    }
+
+    /// Forcefully kill the process (SIGKILL equivalent).
+    ///
+    /// This is the *escalation* signal used when [`terminate`](Self::terminate)
+    /// did not stop the process within the grace period.
     fn kill(&mut self);
 
     /// Wait for the process to exit and return its exit code.
@@ -30,9 +47,45 @@ pub trait BackgroundHandle: Debug + Send {
     /// Returns `Some(exit_code)` if the process has exited, or `None` if it
     /// is still running.
     fn try_wait(&mut self) -> Option<i32>;
+
+    /// The OS process identifier, for signal delivery.
+    ///
+    /// Returns `None` on executors that do not expose a PID (e.g. the
+    /// container executor tracks a PID inside the container instead). The
+    /// shell [`BackgroundHandle`] impl for [`std::process::Child`] returns
+    /// `Some(child.id())`.
+    ///
+    /// Currently only used by the Unix `terminate` implementation to deliver
+    /// SIGTERM; on platforms that do not use it the method is still part of
+    /// the trait surface for future executors.
+    #[allow(dead_code)]
+    fn pid(&self) -> Option<i32> {
+        None
+    }
 }
 
 impl BackgroundHandle for std::process::Child {
+    fn terminate(&mut self) {
+        // On Unix, send SIGTERM so the process can shut down gracefully.
+        // On Windows there is no SIGTERM equivalent, so fall back to the
+        // std `kill` (TerminateProcess).
+        #[cfg(not(windows))]
+        {
+            if let Some(pid) = self.pid() {
+                // SAFETY: the PID comes from `Child::id()` which is the
+                // child's real OS PID; SIGTERM (15) is a valid signal.
+                // `kill(2)` with a real PID and a valid signal is safe.
+                unsafe {
+                    libc::kill(pid, libc::SIGTERM);
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            let _ = std::process::Child::kill(self);
+        }
+    }
+
     fn kill(&mut self) {
         let _ = std::process::Child::kill(self);
     }
@@ -47,5 +100,12 @@ impl BackgroundHandle for std::process::Child {
         std::process::Child::try_wait(self)
             .ok()
             .and_then(|status| status?.code())
+    }
+
+    fn pid(&self) -> Option<i32> {
+        // `Child::id()` returns `u32`; the trait returns `i32`. PIDs are
+        // always positive and fit in i32 on all real platforms.
+        #[allow(clippy::cast_possible_wrap)]
+        Some(self.id() as i32)
     }
 }

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -380,14 +380,21 @@ impl Executor for ContainerExecutor {
         let env = self.container_env();
         let working_dir = self.working_dir.clone();
 
-        // Wrap the script so it records its PID inside the container.
-        // This lets us kill the background process later via another exec.
+        // Wrap the script so it records its PID inside the container and
+        // writes the child's exit code to a separate file when it exits.
+        //   - `pid_file`  — used by kill() and try_wait() to find the PID
+        //   - `exit_file` — written by the wrapper after the child exits
         let bg_num = BG_COUNTER.fetch_add(1, Ordering::SeqCst);
         let pid_file = format!("/tmp/.specdown_bg_{bg_num}");
-        let wrapped_code = format!("echo $$ > {pid_file}; exec {code_string}");
+        let exit_file = format!("/tmp/.specdown_bg_exit_{bg_num}");
+        // The wrapper writes the shell PID to `pid_file` and then runs the
+        // user script in the foreground.  When the script exits the wrapper
+        // writes `$?` to `exit_file` and itself terminates, so `kill -0` on
+        // the PID will fail once the background work is done.
+        let wrapped_code = format!("echo $$ > {pid_file}\n{code_string}\necho $? > {exit_file}");
         let cmd = self.exec_command(&wrapped_code);
 
-        let exec_id = self.runtime.block_on(async move {
+        self.runtime.block_on(async move {
             let exec = docker
                 .create_exec(
                     &container_id,
@@ -403,7 +410,7 @@ impl Executor for ContainerExecutor {
                     message: format!("Failed to create background exec: {err}"),
                 })?;
 
-            // Start detached so it runs in the background
+            // Start detached so it runs in the background.
             docker
                 .start_exec(
                     &exec.id,
@@ -417,7 +424,7 @@ impl Executor for ContainerExecutor {
                     message: format!("Failed to start background exec: {err}"),
                 })?;
 
-            Ok::<String, Error>(exec.id)
+            Ok::<(), Error>(())
         })?;
 
         let handle_runtime = tokio::runtime::Builder::new_current_thread()
@@ -429,8 +436,8 @@ impl Executor for ContainerExecutor {
 
         Ok(Box::new(ContainerBackgroundHandle {
             container_id: container_id_for_handle,
-            exec_id,
             pid_file,
+            exit_file,
             docker: self.docker.clone(),
             runtime: handle_runtime,
         }) as Box<dyn BackgroundHandle>)
@@ -499,13 +506,15 @@ impl Drop for ContainerExecutor {
 /// A handle to a background process running inside the persistent
 /// container via Docker exec.
 ///
-/// The process is tracked by its exec ID. To kill it, we read the PID
-/// (recorded at spawn time) and send `SIGTERM` from another exec.
+/// The process is tracked by its PID file (`pid_file`).  To check whether
+/// the process is still alive we run `kill -0 $(cat <pid_file>)` inside
+/// the container via another exec; to determine the exit code we read
+/// the `exit_file` that the wrapper script writes when the child exits.
 #[derive(Debug)]
 pub struct ContainerBackgroundHandle {
     container_id: String,
-    exec_id: String,
     pid_file: String,
+    exit_file: String,
     docker: Docker,
     runtime: tokio::runtime::Runtime,
 }
@@ -514,14 +523,18 @@ impl BackgroundHandle for ContainerBackgroundHandle {
     fn kill(&mut self) {
         let container_id = self.container_id.clone();
         let pid_file = self.pid_file.clone();
+        let exit_file = self.exit_file.clone();
         let docker = self.docker.clone();
         let _ = self.runtime.block_on(async move {
             // Kill the background process using its recorded PID, then
-            // clean up the PID file.
+            // clean up both the PID file and the exit-code file.
             let kill_cmd = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("kill -TERM $(cat {pid_file}) 2>/dev/null; rm -f {pid_file}"),
+                format!(
+                    "kill -TERM $(cat {pid_file}) 2>/dev/null; \
+                     rm -f {pid_file} {exit_file}"
+                ),
             ];
             let exec = docker
                 .create_exec(
@@ -542,19 +555,96 @@ impl BackgroundHandle for ContainerBackgroundHandle {
     }
 
     fn try_wait(&mut self) -> Option<i32> {
-        let exec_id = self.exec_id.clone();
+        let container_id = self.container_id.clone();
+        let pid_file = self.pid_file.clone();
+        let exit_file = self.exit_file.clone();
         let docker = self.docker.clone();
         self.runtime.block_on(async move {
-            match docker.inspect_exec(&exec_id).await {
-                Ok(info) => {
-                    if info.running == Some(true) {
-                        None
-                    } else {
-                        info.exit_code.map(|c| i32::try_from(c).unwrap_or(0))
+            // Run `kill -0 $(cat <pid_file>)` inside the container.
+            // Exit 0  → process still alive → return None.
+            // Non-zero → process dead → read exit_file for the exit code.
+            let check_cmd = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("kill -0 $(cat {pid_file}) 2>/dev/null"),
+            ];
+
+            let exec = docker
+                .create_exec(
+                    &container_id,
+                    CreateExecOptions::<String> {
+                        cmd: Some(check_cmd),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .ok()?;
+
+            let start_result = docker
+                .start_exec(&exec.id, None::<StartExecOptions>)
+                .await
+                .ok()?;
+
+            // Drain the output stream so the exec completes cleanly.
+            if let bollard::exec::StartExecResults::Attached {
+                output: mut output_stream,
+                ..
+            } = start_result
+            {
+                while let Some(msg) = output_stream.next().await {
+                    match msg {
+                        Ok(_) => {}
+                        Err(_) => break,
                     }
                 }
-                Err(_) => None,
             }
+
+            // Inspect the exec to get the exit code of `kill -0`.
+            let inspect = docker.inspect_exec(&exec.id).await.ok()?;
+
+            if inspect.exit_code == Some(0) {
+                // Process is still alive.
+                return None;
+            }
+
+            // Process is dead — read the exit code from the exit file.
+            let read_cmd = vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("cat {exit_file} 2>/dev/null || echo 0"),
+            ];
+
+            let read_exec = docker
+                .create_exec(
+                    &container_id,
+                    CreateExecOptions::<String> {
+                        cmd: Some(read_cmd),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .ok()?;
+
+            let start_result = docker
+                .start_exec(&read_exec.id, None::<StartExecOptions>)
+                .await
+                .ok()?;
+
+            let mut exit_code_str = String::new();
+            if let bollard::exec::StartExecResults::Attached {
+                output: mut output_stream,
+                ..
+            } = start_result
+            {
+                while let Some(msg) = output_stream.next().await {
+                    if let Ok(LogOutput::StdOut { message }) = msg {
+                        exit_code_str.push_str(&String::from_utf8_lossy(&message));
+                    }
+                }
+            }
+
+            let code = exit_code_str.trim().parse::<i32>().unwrap_or(0);
+            Some(code)
         })
     }
 }
@@ -719,6 +809,79 @@ mod tests {
         while handle.try_wait().is_none() {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_try_wait_returns_none_while_running() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-try-wait-none",
+        )
+        .expect("executor to be created");
+
+        let mut handle = executor
+            .spawn(&ScriptCode("sleep 10".to_string()))
+            .expect("spawn to succeed");
+
+        // Give the container a moment to start the background process.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // While the process is running, try_wait should return None.
+        assert_eq!(
+            handle.try_wait(),
+            None,
+            "try_wait should return None while the background process is still running"
+        );
+
+        // Clean up.
+        handle.kill();
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_try_wait_returns_some_after_exit() {
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-try-wait-some",
+        )
+        .expect("executor to be created");
+
+        let mut handle = executor
+            .spawn(&ScriptCode("exit 42".to_string()))
+            .expect("spawn to succeed");
+
+        // Wait for the process to exit and the exit file to be written.
+        let mut result = None;
+        for _ in 0..60 {
+            if let Some(code) = handle.try_wait() {
+                result = Some(code);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        assert_eq!(
+            result,
+            Some(42),
+            "try_wait should return Some(42) after the background process exits with code 42"
+        );
     }
 
     #[test]

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -529,14 +529,34 @@ impl BackgroundHandle for ContainerBackgroundHandle {
         let exit_file = self.exit_file.clone();
         let docker = self.docker.clone();
         let _ = self.runtime.block_on(async move {
-            // Kill the background process using its recorded PID, then
-            // clean up both the PID file and the exit-code file.
+            // Kill the background process group and record a non-zero
+            // sentinel exit code.
+            //
+            // We use SIGKILL on the process group (`kill -KILL -<pgid>`)
+            // rather than SIGTERM on the shell PID for two reasons:
+            //
+            // 1. SIGTERM to the shell doesn't interrupt a foreground
+            //    child (e.g. `sleep 60`); bash only runs the EXIT trap
+            //    *after* the foreground command returns, so the trap
+            //    would never fire and `exit_file` would stay empty.
+            //
+            // 2. SIGKILL cannot be trapped, so the EXIT trap won't fire
+            //    either.  We therefore write a sentinel exit code (137 =
+            //    128 + SIGKILL) to `exit_file` ourselves, so that a
+            //    subsequent `try_wait` reads a non-zero code instead of
+            //    falling back to `Some(0)`.
+            //
+            // We remove `pid_file` (so `try_wait` knows the process is
+            // dead) but leave `exit_file` in place with the sentinel
+            // value so `try_wait` can report the kill.
             let kill_cmd = vec![
                 "sh".to_string(),
                 "-c".to_string(),
                 format!(
-                    "kill -TERM $(cat {pid_file}) 2>/dev/null; \
-                     rm -f {pid_file} {exit_file}"
+                    "kill -KILL -$(cat {pid_file}) 2>/dev/null; \
+                     kill -KILL $(cat {pid_file}) 2>/dev/null; \
+                     echo 137 > {exit_file}; \
+                     rm -f {pid_file}"
                 ),
             ];
             let exec = docker
@@ -579,7 +599,11 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                 format!("test -f {pid_file} && kill -0 $(cat {pid_file}) 2>/dev/null"),
             ];
 
-            let exec = docker
+            // If create_exec fails, the container is gone (removed or
+            // crashed).  The background process running inside it is
+            // definitely dead — return a non-zero exit code rather than
+            // None ("still running"), which would be misleading.
+            let Ok(exec) = docker
                 .create_exec(
                     &container_id,
                     CreateExecOptions::<String> {
@@ -591,12 +615,14 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                     },
                 )
                 .await
-                .ok()?;
+            else {
+                return Some(1);
+            };
 
-            let start_result = docker
-                .start_exec(&exec.id, None::<StartExecOptions>)
-                .await
-                .ok()?;
+            let Ok(start_result) = docker.start_exec(&exec.id, None::<StartExecOptions>).await
+            else {
+                return Some(1);
+            };
 
             // Drain the output stream so the exec completes cleanly.
             if let bollard::exec::StartExecResults::Attached {
@@ -613,7 +639,10 @@ impl BackgroundHandle for ContainerBackgroundHandle {
             }
 
             // Inspect the exec to get the exit code of the liveness check.
-            let inspect = docker.inspect_exec(&exec.id).await.ok()?;
+            // If inspection fails (container gone mid-check), treat as dead.
+            let Ok(inspect) = docker.inspect_exec(&exec.id).await else {
+                return Some(1);
+            };
 
             // If the exec hasn't completed yet (exit_code is None), the
             // liveness check is still running or Docker hasn't finalised the
@@ -626,13 +655,18 @@ impl BackgroundHandle for ContainerBackgroundHandle {
             }
 
             // Process is dead — read the exit code from the exit file.
+            // If the exit file doesn't exist (e.g. process was killed
+            // before the trap could write), fall back to a non-zero
+            // sentinel so we don't report Some(0) (which would mask the
+            // death).  The EXIT trap writes the real exit code (or signal
+            // exit code like 143 for SIGTERM) to this file.
             let read_cmd = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("cat {exit_file} 2>/dev/null || echo 0"),
+                format!("cat {exit_file} 2>/dev/null || echo 1"),
             ];
 
-            let read_exec = docker
+            let Ok(read_exec) = docker
                 .create_exec(
                     &container_id,
                     CreateExecOptions::<String> {
@@ -644,12 +678,16 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                     },
                 )
                 .await
-                .ok()?;
+            else {
+                return Some(1);
+            };
 
-            let start_result = docker
+            let Ok(start_result) = docker
                 .start_exec(&read_exec.id, None::<StartExecOptions>)
                 .await
-                .ok()?;
+            else {
+                return Some(1);
+            };
 
             let mut exit_code_str = String::new();
             if let bollard::exec::StartExecResults::Attached {
@@ -664,7 +702,7 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                 }
             }
 
-            let code = exit_code_str.trim().parse::<i32>().unwrap_or(0);
+            let code = exit_code_str.trim().parse::<i32>().unwrap_or(1);
             Some(code)
         })
     }
@@ -902,6 +940,189 @@ mod tests {
             result,
             Some(42),
             "try_wait should return Some(42) after the background process exits with code 42"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_try_wait_returns_none_when_pid_file_missing() {
+        // Edge case: try_wait is called before the background process has
+        // had a chance to write its pid_file.  The process has not exited —
+        // it simply hasn't started yet — so try_wait should return None
+        // ("still running"), not Some(0) (which would be misread as
+        // successful completion).
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-pid-file-missing",
+        )
+        .expect("executor to be created");
+
+        // Spawn a process that delays writing its pid_file by sleeping first
+        // in the wrapper — but actually the wrapper writes pid_file
+        // immediately, so instead we test the real edge case: call try_wait
+        // immediately after spawn before the container exec has started.
+        let mut handle = executor
+            .spawn(&ScriptCode("sleep 30".to_string()))
+            .expect("spawn to succeed");
+
+        // Immediately try_wait — the pid_file may not exist yet because the
+        // detached exec hasn't started running the wrapper.  This should
+        // return None ("not started / still running"), not Some(0).
+        let result = handle.try_wait();
+
+        assert!(
+            result.is_none(),
+            "try_wait should return None when pid_file doesn't exist yet (process not started), \
+             got {:?} — Some(0) would be mistaken for successful completion",
+            result
+        );
+
+        // Clean up.
+        handle.kill();
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_try_wait_after_kill_returns_signal_exit_code() {
+        // Edge case (#4): after kill() sends SIGTERM, try_wait should
+        // report the signal exit code (143 = 128 + SIGTERM), not Some(0).
+        // Previously kill() removed both pid_file AND exit_file, so
+        // try_wait fell back to `echo 0` and reported Some(0) — masking
+        // the fact that the process was killed.
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-kill-exit-code",
+        )
+        .expect("executor to be created");
+
+        let mut handle = executor
+            .spawn(&ScriptCode("sleep 60".to_string()))
+            .expect("spawn to succeed");
+
+        // Give the process time to start.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // Kill the process (sends SIGKILL to the process group).
+        handle.kill();
+
+        // Poll try_wait until it returns Some — the process was killed so
+        // it should report a signal exit code, not 0.
+        let mut result = None;
+        for _ in 0..60 {
+            if let Some(code) = handle.try_wait() {
+                result = Some(code);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        assert!(
+            result.is_some(),
+            "try_wait should return Some(code) after kill, not None"
+        );
+        let code = result.unwrap();
+        // SIGKILL produces exit code 137 (128 + 9).  kill() writes this
+        // sentinel to exit_file because SIGKILL can't be trapped.  Accept
+        // any non-zero code — the key assertion is that it's NOT 0 (which
+        // would mask the kill).
+        assert_ne!(
+            code, 0,
+            "try_wait should report a non-zero exit code after kill (SIGKILL → 137), not 0"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires Docker daemon"]
+    fn container_executor_try_wait_returns_some_when_container_removed() {
+        // Edge case (#3b): when the container itself has been removed
+        // (e.g. by external cleanup or a crash), try_wait should return
+        // Some(non-zero) indicating the process is dead, not None
+        // ("still running").  Previously create_exec failed and the
+        // error was silently turned into None.
+        if !docker_available() {
+            return;
+        }
+        let executor = ContainerExecutor::new::<PathBuf>(
+            "bash:5",
+            "bash -c",
+            &[],
+            &[],
+            &[],
+            &[],
+            "test-container-gone",
+        )
+        .expect("executor to be created");
+
+        // Force the container to be created by running a simple command.
+        let _ = executor
+            .execute(&ScriptCode("true".to_string()))
+            .expect("execute to create container");
+
+        // Read the container_id from the executor (tests are in the same
+        // module so private fields are accessible).
+        let container_id = executor
+            .container_id
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("container to be created");
+
+        // Spawn a background process in the now-existing container.
+        let mut handle = executor
+            .spawn(&ScriptCode("sleep 60".to_string()))
+            .expect("spawn to succeed");
+
+        // Give the process time to start.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // Force-remove the container out from under the handle, simulating
+        // external cleanup or a crash.
+        let docker = bollard::Docker::connect_with_socket_defaults().expect("docker connect");
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async move {
+            use bollard::container::RemoveContainerOptions;
+            docker
+                .remove_container(
+                    &container_id,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await
+                .expect("remove container");
+        });
+
+        // Now try_wait — the container is gone.  This should return
+        // Some(non-zero) (dead), not None (still running).
+        let result = handle.try_wait();
+
+        assert!(
+            result.is_some(),
+            "try_wait should return Some(code) when the container is gone (process is dead), \
+             got None — None means 'still running' which is incorrect when the container \
+             has been removed"
+        );
+        let code = result.unwrap();
+        assert_ne!(
+            code, 0,
+            "exit code should be non-zero when the container was removed, not 0"
         );
     }
 

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -461,12 +461,14 @@ impl Executor for ContainerExecutor {
             &self.binds,
             label,
         )
-        .map(|e| Box::new(e) as Box<dyn Executor>)
-        .unwrap_or_else(|err| {
-            // If we can't create a new executor, create a dummy that
-            // returns the error on first use. This should be extremely rare.
-            Box::new(super::executor::FailedExecutor(err))
-        })
+        .map_or_else(
+            |err| {
+                // If we can't create a new executor, create a dummy that
+                // returns the error on first use. This should be extremely rare.
+                Box::new(super::executor::FailedExecutor(err)) as Box<dyn Executor>
+            },
+            |e| Box::new(e) as Box<dyn Executor>,
+        )
     }
 }
 
@@ -537,24 +539,6 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                 .ok()?;
             Some(())
         });
-    }
-
-    fn wait(&mut self) -> Option<i32> {
-        let exec_id = self.exec_id.clone();
-        let docker = self.docker.clone();
-        self.runtime.block_on(async move {
-            loop {
-                match docker.inspect_exec(&exec_id).await {
-                    Ok(info) => {
-                        if info.running != Some(true) {
-                            return info.exit_code.map(|c| i32::try_from(c).unwrap_or(0));
-                        }
-                    }
-                    Err(_) => return None,
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-        })
     }
 
     fn try_wait(&mut self) -> Option<i32> {
@@ -732,7 +716,9 @@ mod tests {
             .expect("spawn to succeed");
 
         handle.kill();
-        let _ = handle.wait();
+        while handle.try_wait().is_none() {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
     }
 
     #[test]

--- a/src/runner/container_executor.rs
+++ b/src/runner/container_executor.rs
@@ -387,11 +387,14 @@ impl Executor for ContainerExecutor {
         let bg_num = BG_COUNTER.fetch_add(1, Ordering::SeqCst);
         let pid_file = format!("/tmp/.specdown_bg_{bg_num}");
         let exit_file = format!("/tmp/.specdown_bg_exit_{bg_num}");
-        // The wrapper writes the shell PID to `pid_file` and then runs the
-        // user script in the foreground.  When the script exits the wrapper
-        // writes `$?` to `exit_file` and itself terminates, so `kill -0` on
-        // the PID will fail once the background work is done.
-        let wrapped_code = format!("echo $$ > {pid_file}\n{code_string}\necho $? > {exit_file}");
+        // The wrapper writes the shell PID to `pid_file`, installs an EXIT
+        // trap that records `$?` to `exit_file`, and then runs the user
+        // script in the foreground.  Using `trap ... EXIT` (instead of a
+        // trailing `echo $?` line) ensures the exit code is captured even
+        // when the script calls `exit N` or is terminated by a signal —
+        // both of which bypass any statement after the script body.
+        let wrapped_code =
+            format!("echo $$ > {pid_file}\ntrap 'echo $? > {exit_file}' EXIT\n{code_string}");
         let cmd = self.exec_command(&wrapped_code);
 
         self.runtime.block_on(async move {
@@ -560,13 +563,20 @@ impl BackgroundHandle for ContainerBackgroundHandle {
         let exit_file = self.exit_file.clone();
         let docker = self.docker.clone();
         self.runtime.block_on(async move {
-            // Run `kill -0 $(cat <pid_file>)` inside the container.
-            // Exit 0  → process still alive → return None.
-            // Non-zero → process dead → read exit_file for the exit code.
+            // Inside the container:
+            //   1. If `pid_file` does not exist, the background process has
+            //      not started yet → treat as "still running" (return None).
+            //      Without this guard, a missing `pid_file` makes `cat`
+            //      emit nothing, so `kill -0` runs with no PID argument and
+            //      fails — which would otherwise be misread as "dead" and
+            //      fall through to the exit-file branch (returning Some(0)).
+            //   2. If `pid_file` exists, run `kill -0 $(cat <pid_file>)`.
+            //      Exit 0  → process still alive → return None.
+            //      Non-zero → process dead → read exit_file for the exit code.
             let check_cmd = vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                format!("kill -0 $(cat {pid_file}) 2>/dev/null"),
+                format!("test -f {pid_file} && kill -0 $(cat {pid_file}) 2>/dev/null"),
             ];
 
             let exec = docker
@@ -574,6 +584,9 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                     &container_id,
                     CreateExecOptions::<String> {
                         cmd: Some(check_cmd),
+                        attach_stdout: Some(true),
+                        attach_stderr: Some(true),
+                        attach_stdin: Some(false),
                         ..Default::default()
                     },
                 )
@@ -599,10 +612,15 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                 }
             }
 
-            // Inspect the exec to get the exit code of `kill -0`.
+            // Inspect the exec to get the exit code of the liveness check.
             let inspect = docker.inspect_exec(&exec.id).await.ok()?;
 
-            if inspect.exit_code == Some(0) {
+            // If the exec hasn't completed yet (exit_code is None), the
+            // liveness check is still running or Docker hasn't finalised the
+            // status — treat as "not done yet" and return None.
+            let check_exit_code = inspect.exit_code?;
+
+            if check_exit_code == 0 {
                 // Process is still alive.
                 return None;
             }
@@ -619,6 +637,9 @@ impl BackgroundHandle for ContainerBackgroundHandle {
                     &container_id,
                     CreateExecOptions::<String> {
                         cmd: Some(read_cmd),
+                        attach_stdout: Some(true),
+                        attach_stderr: Some(true),
+                        attach_stdin: Some(false),
                         ..Default::default()
                     },
                 )

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -20,4 +20,15 @@ pub enum Error {
     #[cfg(not(feature = "container"))]
     #[error("The container executor feature is not enabled. Rebuild specdown with `--features container`")]
     ContainerFeatureNotEnabled,
+    /// A `background` block with a `ready_when` condition exited before the
+    /// condition became true.
+    #[error("Background script '{script_name}' exited with code {exit_code} before the ready_when condition was met")]
+    BackgroundExitedBeforeReady { script_name: String, exit_code: i32 },
+    /// A `ready_when` condition was not satisfied within the timeout.
+    #[error("Background script '{script_name}' did not become ready within {timeout_secs} seconds (ready_when: {condition})")]
+    ReadyWhenTimeout {
+        script_name: String,
+        timeout_secs: u32,
+        condition: String,
+    },
 }

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -47,8 +47,8 @@ pub trait Executor: Send + Sync {
     /// The default implementation returns a `FailedExecutor` that produces
     /// a `BackgroundNotSupported` error on first use. Executors that support
     /// parallel execution should override this.
-    fn clone_box(&self, _label: &str) -> Box<dyn Executor> {
-        let _ = _label;
+    fn clone_box(&self, label: &str) -> Box<dyn Executor> {
+        let _ = label;
         Box::new(FailedExecutor(Error::BackgroundNotSupported))
     }
 }

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -157,9 +157,10 @@ impl Executor for ShellExecutor {
             format!("{} {}", self.command, self.args.join(" "))
         };
 
-        ShellExecutor::new::<String>(&shell_cmd, &env, &self.unset_env, &paths)
-            .map(|e| Box::new(e) as Box<dyn Executor>)
-            .unwrap_or_else(|err| Box::new(super::executor::FailedExecutor(err)))
+        ShellExecutor::new::<String>(&shell_cmd, &env, &self.unset_env, &paths).map_or_else(
+            |err| Box::new(super::executor::FailedExecutor(err)) as Box<dyn Executor>,
+            |e| Box::new(e) as Box<dyn Executor>,
+        )
     }
 }
 

--- a/src/runner/shell_executor.rs
+++ b/src/runner/shell_executor.rs
@@ -128,6 +128,17 @@ impl Executor for ShellExecutor {
         command.stdout(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
 
+        // Put the child in its own process group so we can kill the entire
+        // process tree (child + grandchildren) on shutdown. Without this,
+        // grandchildren (e.g. python3 spawned by bash) get reparented to PID 1
+        // when the direct child (bash) is killed, becoming orphans that hold
+        // ports and resources indefinitely.
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+
         command
             .spawn()
             .map(|child| Box::new(child) as Box<dyn BackgroundHandle>)

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,10 +113,48 @@ pub struct CreateFileAction {
     pub file_content: FileContent,
 }
 
+/// A readiness condition for a `background` block's `ready_when` argument.
+///
+/// When set, the runner spawns the background script (non-blocking) and then
+/// polls this condition until it is satisfied before proceeding to the next
+/// action. This replaces the fragile `sleep 1` pattern where a test author
+/// has to guess how long a server takes to bind a port or write a readiness
+/// file.
+///
+/// The condition string is parsed from the `ready_when` argument. Supported
+/// forms:
+/// - `file:<path>` - succeeds when the given path exists on disk.
+/// - `port:<n>` - succeeds when a TCP connection to `127.0.0.1:<n>` succeeds.
+/// - `exit:<shell command>` - succeeds when the shell command exits with
+///   code 0.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadyWhen {
+    /// Succeeds when the file at the given path exists.
+    FileExists(FilePath),
+    /// Succeeds when a TCP connection to `127.0.0.1:<port>` can be opened.
+    PortOpen(u16),
+    /// Succeeds when the given shell command exits with code 0.
+    CheckExitZero(ScriptCode),
+}
+
+/// How many seconds to wait for a `ready_when` condition before failing.
+///
+/// This is the default timeout used when a `ready_when` condition is set but
+/// no explicit `timeout_secs` argument is provided.
+pub const DEFAULT_READY_WHEN_TIMEOUT_SECS: u32 = 30;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BackgroundAction {
     pub script_name: Option<ScriptName>,
     pub script_code: ScriptCode,
+    /// When set, the runner polls this condition after spawning and blocks
+    /// until it is satisfied (or `timeout_secs` elapses). When `None`, the
+    /// block behaves exactly as before - spawn and proceed immediately.
+    pub ready_when: Option<ReadyWhen>,
+    /// Readiness timeout in seconds. Defaults to
+    /// [`DEFAULT_READY_WHEN_TIMEOUT_SECS`] when `ready_when` is set and this
+    /// is `None`.
+    pub timeout_secs: Option<u32>,
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -229,18 +229,6 @@ fn test_doc_background_scripts() {
 }
 
 #[test]
-fn test_doc_background_ready_when() {
-    // The ready_when examples are part of background_scripts.md, but we run
-    // a focused smoke test here to ensure the ready_when feature (file,
-    // port, and exit forms) works end-to-end via the built binary.
-    let result = specdown_run_with_path()
-        .arg("docs/specs/background_scripts.md")
-        .ok();
-
-    assert_ok(&result);
-}
-
-#[test]
 fn test_doc_container_executor() {
     let result = specdown_run_with_path()
         .arg("docs/specs/container_executor.md")

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -229,6 +229,18 @@ fn test_doc_background_scripts() {
 }
 
 #[test]
+fn test_doc_background_ready_when() {
+    // The ready_when examples are part of background_scripts.md, but we run
+    // a focused smoke test here to ensure the ready_when feature (file,
+    // port, and exit forms) works end-to-end via the built binary.
+    let result = specdown_run_with_path()
+        .arg("docs/specs/background_scripts.md")
+        .ok();
+
+    assert_ok(&result);
+}
+
+#[test]
 fn test_doc_container_executor() {
     let result = specdown_run_with_path()
         .arg("docs/specs/container_executor.md")

--- a/tests/command_test.rs
+++ b/tests/command_test.rs
@@ -35,12 +35,7 @@ fn specdown_run_with_path() -> Command {
 
 #[test]
 fn test_readme() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
-        .arg("README.md")
-        .ok();
+    let result = specdown_run_with_path().arg("README.md").ok();
 
     assert_ok(&result);
 }
@@ -60,10 +55,7 @@ fn test_doc_index() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_display_help() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/cli/display_help.md")
         .ok();
 
@@ -82,10 +74,7 @@ fn test_doc_running_specs() {
 
 #[test]
 fn test_doc_creating_test_files() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/specs/creating_test_files.md")
         .ok();
 
@@ -94,10 +83,7 @@ fn test_doc_creating_test_files() {
 
 #[test]
 fn test_doc_verifying_script_output() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/specs/verifying_script_output.md")
         .ok();
 
@@ -106,10 +92,7 @@ fn test_doc_verifying_script_output() {
 
 #[test]
 fn test_doc_verifying_exit_codes() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/specs/verifying_exit_codes.md")
         .ok();
 
@@ -118,10 +101,7 @@ fn test_doc_verifying_exit_codes() {
 
 #[test]
 fn test_doc_global_environment_variables() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/specs/global_environment_variables.md")
         .ok();
 
@@ -130,10 +110,7 @@ fn test_doc_global_environment_variables() {
 
 #[test]
 fn test_doc_output_expectations() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/specs/output_expectations.md")
         .ok();
 
@@ -184,10 +161,7 @@ fn test_doc_escaped_quotes_in_string_arguments() {
 
 #[test]
 fn test_doc_skipping_code_blocks() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/specs/skipping_code_blocks.md")
         .ok();
 
@@ -197,11 +171,7 @@ fn test_doc_skipping_code_blocks() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_completion() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("docs/cli/completion.md")
-        .ok();
+    let result = specdown_run_with_path().arg("docs/cli/completion.md").ok();
 
     assert_ok(&result);
 }
@@ -209,10 +179,7 @@ fn test_doc_completion() {
 #[cfg(not(windows))]
 #[test]
 fn test_doc_stripping_specs() {
-    let result = Command::cargo_bin("specdown")
-        .unwrap()
-        .arg("run")
-        .arg("--temporary-workspace-dir")
+    let result = specdown_run_with_path()
         .arg("docs/cli/stripping_specs.md")
         .ok();
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `ContainerBackgroundHandle::try_wait` for container background processes, adds edge-case test coverage, and corrects exit code propagation after `kill()`.

### 1. Replace `inspect_exec` with PID-alive check (`kill -0`)

The background process is started via `start_exec(detach: true)`. The old `try_wait` checked `inspect_exec(exec_id).running` — but a detached exec completes immediately while the background process keeps running, so `try_wait` returned `Some(0)` prematurely. This caused `stop()` to report `Exited(0)` with the server still alive.

**Fix**: Check the recorded PID inside the container via `kill -0` against the pid_file instead of the exec instance status.

### 2. Capture exit code with EXIT trap

The spawn wrapper wrote `echo $? > {exit_file}` after the user script. But when the script calls `exit N` or is killed by a signal, the shell exits before reaching that line — so `exit_file` was never written and `try_wait` returned `Some(0)` instead of the real exit code.

**Fix**: Use `trap 'echo $? > {exit_file}' EXIT` before the script runs, ensuring the exit code is captured even when the script calls `exit` or is signal-killed.

### 3. Container-gone detection (new)

When the container itself is removed (external cleanup, crash), `create_exec` fails. Previously the error was silently turned into `None` ("still running") via `.ok()?`. Now `try_wait` returns `Some(1)` (non-zero, dead) when Docker API calls fail, correctly indicating the process is dead.

### 4. kill() exit code propagation (new)

Previously `kill()` removed both `pid_file` AND `exit_file`, and used `SIGTERM` on the shell PID. Two problems:
- `SIGTERM` to the shell doesn't interrupt a foreground child (e.g. `sleep 60`); bash only runs the EXIT trap *after* the foreground command returns, so the trap never fires and `exit_file` stays empty.
- Even if the trap fired, removing `exit_file` meant `try_wait` fell back to `Some(0)`, masking the kill.

**Fix**: `kill()` now uses `SIGKILL` on the process group (`kill -KILL -PGID`) which kills both shell and child immediately, and writes a sentinel exit code (137 = 128 + SIGKILL) to `exit_file` directly (SIGKILL can't be trapped). Only `pid_file` is removed; `exit_file` is left with the sentinel so `try_wait` reports the correct non-zero exit code.

### 5. Exit-file fallback (new)

When the exit file doesn't exist or can't be parsed, `try_wait` now falls back to `Some(1)` instead of `Some(0)`, so a missing exit code is never mistaken for successful completion.

## Test Plan

- [x] `cargo build --features container` — passes
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic` — 0 warnings
- [x] `cargo test --features container -- --include-ignored` — 234 tests pass (217 unit + 17 integration), 0 failures, 0 ignored
- [x] `make check` — passes

New tests (all require Docker, `#[ignore]` by default):
- `container_executor_try_wait_returns_none_when_pid_file_missing` — try_wait returns None when pid_file doesn't exist yet (process not started)
- `container_executor_try_wait_after_kill_returns_signal_exit_code` — try_wait returns non-zero (137) after kill(), not Some(0)
- `container_executor_try_wait_returns_some_when_container_removed` — try_wait returns Some(non-zero) when container is gone, not None

Supersedes #620 (closed).
