### PR TITLE
Fix internal links pointing to .md instead of .html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.17"
+  gem "jekyll-relative-links", "~> 0.7"
 end
 
 # Jekyll 4 no longer bundles webrick by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-relative-links (0.7.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.9.0)
@@ -167,6 +169,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.4)
   jekyll-feed (~> 0.17)
+  jekyll-relative-links (~> 0.7)
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data
@@ -208,6 +211,7 @@ CHECKSUMS
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
+  jekyll-relative-links (0.7.0) sha256=831e54c348eeae751845c0d4ac4b244bd73b664341f0e8c9f1803b16f4570835
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.9.0) sha256=0260015a8e1df9bf195cdfb0c675b7b2883fd8cbf12556e1c1cbe36a831c6852
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,10 @@ github_username:  specdown
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-relative-links
+
+relative_links:
+  enabled: true
 
 markdown: kramdown
 


### PR DESCRIPTION
## Summary
- Internal links in the generated docs (`index.md`, `docs/**/*.md`) use plain relative `.md` paths, since that's what renders correctly when viewing the source repo on GitHub itself.
- Jekyll doesn't rewrite those to the built page URLs automatically, so every internal doc link on the live site (e.g. `docs/cli/display_help.md`) 404s.
- Adds and enables the `jekyll-relative-links` plugin, which rewrites relative links to markdown files into the linked page's real site URL at build time.

## Test plan
- [x] `bundle exec jekyll build` locally, confirmed `docs/index.html`'s link to `cli/display_help.md` now renders as `href="/docs/cli/display_help.html"`, and `index.html`'s link to `./docs/index.md` renders as `href="/docs/"`.
- [x] Grepped the built `_site` for any remaining literal `.md"` in `<a href>` tags — none found (the one hit was a code sample referencing a filename, not a link).
- [ ] Confirm the Actions build/deploy succeeds on merge and spot-check links on https://specdown.github.io/specdown/docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)