### PR TITLE
Regenerate docs pages with the new sidebar layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,5 @@ $(GH_PAGES_LOCATION)/logo/logo.png:
 
 $(GH_PAGES_LOCATION)/docs/%.md:
 	mkdir -p "$(@D)"
-	echo "---\nlayout: page\n---\n" >"$@"
+	echo "---\nlayout: docs\n---\n" >"$@"
 	specdown strip "$(subst $(GH_PAGES_LOCATION)/,,$@)" >>"$@"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-<p align="center">
-  <img alt="specdown" src="./logo/logo.png">
-</p>
-
-<p align="center">A tool to test markdown files and drive development from documentation.</p>
+<div align="center" class="hero" markdown="0">
+  <img class="logo" alt="specdown" src="./logo/logo.png">
+  <h1>SpecDown</h1>
+  <p class="tagline">A tool to test markdown files and drive development from documentation.</p>
+  <p class="button-row">
+    <a class="btn btn--primary" href="./docs/index.md">Get Started</a>
+    <a class="btn btn--secondary" href="https://github.com/specdown/specdown">View on GitHub</a>
+  </p>
+</div>
 
 ## This document is an executable specification
 


### PR DESCRIPTION
## Summary

The gh-pages site was recently re-themed (new sidebar-based docs layout, styled homepage hero, light/dark mode). That work landed directly on `gh-pages`, but `docs/*.md` and the homepage are regenerated from this repo on every release by `publish-website.yml`, which runs `make ../gh-pages` using the `Makefile`'s `docs/%.md` and `index.md` rules and overwrites `index.md`/`docs/` on `gh-pages` from `README.md` + `docs/`. Without this fix, the next release would blow away the new design:

- Every generated docs page would revert to `layout: page` (no sidebar), since the Makefile hardcodes that front matter.
- The homepage hero would revert to a plain centered image + tagline, since it's generated from `README.md`.

## Changes

- `Makefile`: the `$(GH_PAGES_LOCATION)/docs/%.md` rule now emits `layout: docs` front matter instead of `layout: page`, matching the sidebar layout added to the theme. `index.md` keeps `layout: page` (unchanged, single-column layout).
- `README.md`: rebuilt the top hero block using the markup/classes the new theme's CSS targets (`hero`, `logo`, `tagline`, `button-row`, `btn`), with plain relative links (no Jekyll Liquid) so it still renders correctly as a plain GitHub README as well as through `specdown strip` into the generated `gh-pages/index.md`.

## Test plan

- [x] Built the `specdown` binary from this branch and ran `make gh-pages GH_PAGES_LOCATION=... --always-make` locally to regenerate the site output.
- [x] Confirmed generated `docs/**/*.md` now have `layout: docs` front matter and `index.md` still has `layout: page`.
- [x] Confirmed the generated `index.md` hero block matches the markup the live `gh-pages` theme expects, with working relative (non-Liquid) links.
- [ ] CI (`publish_website`) will do a real end-to-end regeneration + push to `gh-pages` on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)