### PR TITLE
feat!: convert add-path relative dirs to absolute

### DIFF
--- a/docs/cli/config_file.md
+++ b/docs/cli/config_file.md
@@ -178,7 +178,9 @@ executor = "shell"
 - `shell_command` picks the shell used to run script blocks.
 - `[run.env]` sets environment variables as a table (see above), while
   `unset_env` removes one from the inherited environment.
-- `add_path` prepends a directory to `$PATH`.
+- `add_path` prepends a directory to `$PATH`. Relative paths are resolved from
+  the directory containing `specdown.toml` and converted to absolute paths, so
+  they continue to work when using a temporary workspace.
 - `jobs` controls how many spec files run in parallel.
 - `[run.executor]` selects the executor backend (`shell`, shown here, or
   `container` — see below).

--- a/docs/cli/running_specs.md
+++ b/docs/cli/running_specs.md
@@ -491,8 +491,9 @@ UNSET_ME=1 specdown run --unset-env UNSET_ME unset_environment_variables.md
 ### Adding to `$PATH`
 
 If you want addition paths to be added to your running environment you can use
-`--add-path`. To demonstrate this, let's create a couple of scripts in different
-directories:
+`--add-path`. Relative paths passed on the command line are resolved from the
+working directory where specdown starts. To demonstrate this, let's create a
+couple of scripts in different directories:
 
 ```shell,script(name="create_scripts", expected_exit_code=0)
 mkdir -p vendor/bin

--- a/src/commands/run/config_file.rs
+++ b/src/commands/run/config_file.rs
@@ -5,6 +5,11 @@ use serde::Deserialize;
 use super::settings::RunSettings;
 use crate::runner::Error;
 
+pub struct LoadedConfig {
+    pub settings: RunSettings,
+    pub path: Option<PathBuf>,
+}
+
 /// The default name of the config file looked up in the current directory
 /// when `--config` is not given.
 const DEFAULT_FILE_NAME: &str = "specdown.toml";
@@ -22,36 +27,57 @@ struct ConfigFile {
 /// is an error if it doesn't exist or fails to parse. Otherwise `cwd` is
 /// searched for a `specdown.toml`; if it isn't there, the defaults
 /// (`RunSettings::default()`) are returned rather than an error.
-pub fn load_run_settings(explicit_path: Option<&Path>, cwd: &Path) -> Result<RunSettings, Error> {
-    let (path, is_explicit): (PathBuf, bool) = match explicit_path {
-        Some(p) => (p.to_path_buf(), true),
-        None => (cwd.join(DEFAULT_FILE_NAME), false),
+#[cfg(test)]
+fn load_run_settings(explicit_path: Option<&Path>, cwd: &Path) -> Result<RunSettings, Error> {
+    load_config(explicit_path, cwd).map(|config| config.settings)
+}
+
+pub fn load_config(explicit_path: Option<&Path>, cwd: &Path) -> Result<LoadedConfig, Error> {
+    let (path, error_path, is_explicit): (PathBuf, PathBuf, bool) = if let Some(p) = explicit_path {
+        (make_absolute(p, cwd), p.to_path_buf(), true)
+    } else {
+        let path = cwd.join(DEFAULT_FILE_NAME);
+        (path.clone(), path, false)
     };
 
     let contents = match std::fs::read_to_string(&path) {
         Ok(contents) => contents,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound && !is_explicit => {
-            return Ok(RunSettings::default());
+            return Ok(LoadedConfig {
+                settings: RunSettings::default(),
+                path: None,
+            });
         }
         Err(err) => {
             return Err(Error::ConfigFileLoadFailed {
-                path,
+                path: error_path,
                 message: err.to_string(),
             })
         }
     };
 
     toml::from_str::<ConfigFile>(&contents)
-        .map(|config| config.run)
+        .map(|config| LoadedConfig {
+            settings: config.run,
+            path: Some(path),
+        })
         .map_err(|err| Error::ConfigFileLoadFailed {
-            path,
+            path: error_path,
             message: err.to_string(),
         })
 }
 
+fn make_absolute(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::load_run_settings;
+    use super::{load_config, load_run_settings};
     use crate::commands::run::settings::ExecutorKind;
     use crate::runner::Error;
     use std::fs;
@@ -130,6 +156,22 @@ mod tests {
             load_run_settings(None, dir.path()).expect("expected settings, got an error");
 
         assert_eq!(vec!["A=1".to_string(), "B=2".to_string()], settings.env);
+    }
+
+    #[test]
+    fn test_resolves_relative_add_path_from_config_directory() {
+        let dir = tempfile::tempdir().expect("failed to create a temporary directory");
+        let config_path = dir.path().join("nested").join("custom.toml");
+        fs::create_dir_all(config_path.parent().expect("config should have a parent"))
+            .expect("failed to create config directory");
+        fs::write(&config_path, "[run]\nadd_path = [\"bin\"]\n")
+            .expect("failed to write config file");
+
+        let loaded =
+            load_config(Some(&config_path), dir.path()).expect("expected settings, got an error");
+
+        assert_eq!(Some(config_path), loaded.path);
+        assert_eq!(vec!["bin".to_string()], loaded.settings.add_path);
     }
 
     #[test]

--- a/src/commands/run/mod.rs
+++ b/src/commands/run/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use merge::Merge;
 
@@ -59,9 +59,8 @@ fn create_run_command(config: &Config, cli_settings: &RunSettings) -> Result<Run
     let current_dir = std::env::current_dir().expect("Failed to get current workspace directory");
 
     let mut args = cli_settings.clone();
-    let file_settings =
-        config_file::load_run_settings(config.config_path.as_deref(), &current_dir)?;
-    args.merge(file_settings);
+    let file_config = config_file::load_config(config.config_path.as_deref(), &current_dir)?;
+    args.merge(file_config.settings);
 
     let temp_workspace_dir = args.temporary_workspace_dir;
     let workspace_init_command = args.workspace_init_command.clone();
@@ -78,7 +77,16 @@ fn create_run_command(config: &Config, cli_settings: &RunSettings) -> Result<Run
     };
 
     let unset_env = args.unset_env.clone();
-    let paths = args.add_path.clone();
+    let add_path_base = if cli_settings.add_path.is_empty() {
+        file_config
+            .path
+            .as_deref()
+            .and_then(Path::parent)
+            .unwrap_or(&current_dir)
+    } else {
+        &current_dir
+    };
+    let paths = resolve_add_paths(&args.add_path, add_path_base);
     let file_reader = FileReader::new(current_dir.clone());
     let workspace_per_spec = args.workspace_per_spec;
 
@@ -131,6 +139,20 @@ fn create_run_command(config: &Config, cli_settings: &RunSettings) -> Result<Run
         file_reader,
         jobs,
     })
+}
+
+fn resolve_add_paths(paths: &[String], base: &Path) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| {
+            let path = Path::new(path);
+            if path.is_absolute() {
+                path.to_string_lossy().into_owned()
+            } else {
+                base.join(path).to_string_lossy().into_owned()
+            }
+        })
+        .collect()
 }
 
 /// Builds the `ExecutorFactory` matching the configured executor kind
@@ -239,7 +261,19 @@ fn parse_environment_variable(string: &str) -> (String, String) {
 
 #[cfg(test)]
 mod tests {
-    use super::workspace_per_spec_validation_error;
+    use super::{resolve_add_paths, workspace_per_spec_validation_error};
+    use std::path::Path;
+
+    #[test]
+    fn resolves_relative_paths_against_the_base_directory() {
+        assert_eq!(
+            resolve_add_paths(
+                &["bin".to_string(), "/absolute/bin".to_string()],
+                Path::new("/project"),
+            ),
+            vec!["/project/bin", "/absolute/bin"]
+        );
+    }
 
     #[test]
     fn errors_when_workspace_per_spec_is_set_without_temporary_workspace_dir() {


### PR DESCRIPTION
This is to allow temporary-directory to work with the configuration file and add path without knowing the exact path that needs to be added to the path